### PR TITLE
feat: Add support for typed custom properties

### DIFF
--- a/lib/__tests/lexer-match-property.js
+++ b/lib/__tests/lexer-match-property.js
@@ -9,7 +9,8 @@ const lazy = lazyValues({
     customSyntax: () => fork({
         properties: {
             foo: 'bar',
-            '-baz-foo': 'qux'
+            '-baz-foo': 'qux',
+            '--typed-property': '<color>'
         }
     }),
     customCssWideKeywords: () => fork({
@@ -84,6 +85,27 @@ describe('Lexer#matchProperty()', () => {
 
         assert.strictEqual(match.matched, null);
         assert.strictEqual(match.error.message, 'Lexer matching doesn\'t applicable for custom properties');
+    });
+
+    it('typed custom property', () => {
+        let match;
+
+        match = lazy.customSyntax.lexer.matchProperty('--typed-property', lazy.bar);
+
+        assert.strictEqual(match.matched, null);
+        assert.strictEqual(match.error.rawMessage, 'Mismatch');
+        assert.deepStrictEqual({
+            line: match.error.line,
+            column: match.error.column
+        }, {
+            line: 1,
+            column: 1
+        });
+
+        match = lazy.customSyntax.lexer.matchProperty('--typed-property', 'rgb(0 0 0 / 1)');
+
+        assert(match.matched);
+        assert.strictEqual(match.error, null);
     });
 
     describe('should match css wide keywords', function() {

--- a/lib/lexer/Lexer.js
+++ b/lib/lexer/Lexer.js
@@ -356,8 +356,10 @@ export class Lexer {
         return this.matchProperty(node.property, node.value);
     }
     matchProperty(propertyName, value) {
-        // don't match syntax for a custom property at the moment
-        if (names.property(propertyName).custom) {
+        if (
+            !this.getProperty(propertyName) &&
+            names.property(propertyName).custom
+        ) {
             return buildMatchResult(null, new Error('Lexer matching doesn\'t applicable for custom properties'));
         }
 


### PR DESCRIPTION
This pull request introduces changes to support typed custom properties in the lexer. The most important changes include adding a new typed custom property, updating the lexer to handle these properties, and adding tests to ensure the correct functionality.

Port of
https://github.com/csstree/csstree/pull/256

cc @romainmenke

Enhancements to lexer functionality:

* [`lib/lexer/Lexer.js`](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242L359-R362): Modified the `matchProperty` method to handle typed custom properties by checking if the property is not found and is a custom property.

Testing improvements:

* [`lib/__tests/lexer-match-property.js`](diffhunk://#diff-02ffb908de7190c5ace89f8cbe8ab28a8bec6b9f42f1aac2f1e33da4d8d34b06L12-R13): Added a new typed custom property `--typed-property` and included tests to validate the lexer’s behavior with this property. [[1]](diffhunk://#diff-02ffb908de7190c5ace89f8cbe8ab28a8bec6b9f42f1aac2f1e33da4d8d34b06L12-R13) [[2]](diffhunk://#diff-02ffb908de7190c5ace89f8cbe8ab28a8bec6b9f42f1aac2f1e33da4d8d34b06R90-R110)