### PR TITLE
feat: passthrough env() in lexer syntax matching

### DIFF
--- a/fixtures/definition-syntax/env.json
+++ b/fixtures/definition-syntax/env.json
@@ -1,0 +1,17 @@
+{
+    "should pass through (values with `env()` is always valid for now)": {
+        "syntax": "<bar>",
+        "lexer": {
+            "types": {
+                "bar": "foo"
+            }
+        },
+        "valid": [
+            "foo",
+            "env(name)",
+            "env(name) qux",
+            "ENV(name)",
+            "ENV(name) qux"
+        ]
+    }
+}

--- a/lib/__tests/lexer-match-property.js
+++ b/lib/__tests/lexer-match-property.js
@@ -132,6 +132,12 @@ describe('Lexer#matchProperty()', () => {
                             assert(true);
                             return;
                         }
+
+                        if (
+                            /Matching for a tree with env\(\) is not supported/.test(match.error.message)) {
+                            assert(true);
+                            return;
+                        }
                     }
 
                     assert(match.matched !== null, match.error && match.error.message);

--- a/lib/lexer/Lexer.js
+++ b/lib/lexer/Lexer.js
@@ -63,6 +63,16 @@ function syntaxHasTopLevelCommaMultiplier(syntax) {
     );
 }
 
+function valueHasEnv(tokens) {
+    for (let i = 0; i < tokens.length; i++) {
+        if (tokens[i].value.toLowerCase() === 'env(') {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 function buildMatchResult(matched, error, iterations) {
     return {
         matched,
@@ -78,6 +88,10 @@ function matchSyntax(lexer, syntax, value, useCssWideKeywords) {
 
     if (valueHasVar(tokens)) {
         return buildMatchResult(null, new Error('Matching for a tree with var() is not supported'));
+    }
+
+    if (valueHasEnv(tokens)) {
+        return buildMatchResult(null, new Error('Matching for a tree with env() is not supported'));
     }
 
     if (useCssWideKeywords) {


### PR DESCRIPTION
This pull request includes changes to handle `env()` values in the lexer and improve error handling for unsupported syntax. The most important changes include adding a new function to detect `env()` values, updating the match syntax function to handle `env()` values, and adding test cases to ensure the new functionality works correctly.

Port of:
https://github.com/csstree/csstree/pull/245

cc @romainmenke

Enhancements to lexer functionality:

* [`lib/lexer/Lexer.js`](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242R66-R75): Added a new function `valueHasEnv` to detect `env()` values in tokens and updated the `matchSyntax` function to return an error when `env()` values are detected. [[1]](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242R66-R75) [[2]](diffhunk://#diff-629ab198b211be814fa3ac4242eb8cb58113284fbd3a775cc55bd18d4b6f0242R93-R96)

Test case improvements:

* [`lib/__tests/lexer-match-property.js`](diffhunk://#diff-02ffb908de7190c5ace89f8cbe8ab28a8bec6b9f42f1aac2f1e33da4d8d34b06R135-R140): Added a new condition to check for the error message related to `env()` values and ensure the test passes when this specific error is encountered.

Fixture updates:

* [`fixtures/definition-syntax/env.json`](diffhunk://#diff-ded2e5140bf6ddb0a0b87cffce95abc6d6153063bbc87cd1b10e3b95ac31656dR1-R17): Added a new fixture to test the lexer with various `env()` value scenarios, ensuring that the lexer correctly handles these cases.