### PR TITLE
fix: Add parse.SyntaxError and parse.config types

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1378,12 +1378,28 @@ export interface ParseOptions {
 
 /**
  * A function that parses a CSS string into an abstract syntax tree (AST).
- *
- * @param source - The CSS source string to parse.
- * @param options - Optional configuration for the parser.
- * @returns The parsed CSS as a `CssNode`.
  */
-export type ParseFunction = (source: string, options?: ParseOptions) => CssNode;
+export interface ParseFunction {
+
+    /**
+     * Parses a CSS source string into an abstract syntax tree (AST).
+     * @param source - The CSS source string to parse.
+     * @param options - Optional configuration for the parser.
+     * @returns The parsed CSS as a `CssNode`.
+     * @throws {CSSSyntaxError} If a parsing error occurs, this error will be thrown.
+     */
+    (source: string, options?: ParseOptions): CssNode;
+
+    /**
+     * The error class used for parsing errors.
+     */
+    SyntaxError: typeof CSSSyntaxError;
+
+    /**
+     * The configuration used by the parser.
+     */
+    config: ParseConfig;
+}
 
 /**
  * Parses a CSS string into an abstract syntax tree (AST).
@@ -2119,6 +2135,59 @@ export const url: {
 // Lexer
 // https://github.com/csstree/csstree/blob/master/lib/lexer/Lexer.js
 // ----------------------------------------------------------
+
+/**
+ * Represents a syntax error while parsing CSS code. In the actual code,
+ * this is called `SyntaxError`, but that clashes with the global `SyntaxError` class.
+ * This isn't exported separately but rather as a member of the `parse` function.
+ */
+declare class CSSSyntaxError extends SyntaxError {
+
+    /**
+     * Creates a new instance
+     * @param message The error message describing the syntax error.
+     * @param source The source code where the error occurred.
+     * @param offset The character offset in the source code where the error occurred.
+     * @param line The line number (1-indexed) in the source code where the error occurred.
+     * @param column The column number (1-indexed) in the source code where the error occurred.
+     * @param baseLine The base line number (1-indexed) for the error, used for relative positioning.
+     * @param baseColumn The base column number (1-indexed) for the error, used for relative positioning.
+     */
+    constructor(message: string, source: string, offset: number, line: number, column: number, baseLine?: number, baseColumn?: number);
+
+    /**
+     * The source code where the error occurred.
+     */
+    source: string;
+
+    /**
+     * The character offset in the source code where the error occurred.
+     */
+    offset: number;
+
+    /**
+     * The line number (1-indexed) in the source code where the error occurred.
+     */
+    line: number;
+
+    /**
+     * The column number (1-indexed) in the source code where the error occurred.
+     */
+    column: number;
+
+    /**
+     * The source code fragment around the error, including a specified number of extra lines.
+     * @param extraLines The number of extra lines to include in the fragment.
+     * @return A string containing the source code fragment around the error.
+     * This fragment includes the error line and the specified number of lines before and after it.
+     */
+    sourceFragment(extraLines: number): string;
+
+    /**
+     * The error message formatted with the source fragment.
+     */
+    readonly formattedMessage: string;
+}
 
 /**
  * Represents an error that occurs during the syntax matching process.

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -16,6 +16,10 @@ const astWithOpts = csstree.parse('.example { color: red }', {
     }
 });
 
+const error1 = new csstree.parse.SyntaxError('Unexpected token', 'x', 0, 1, 1);
+const error2 = new csstree.parse.SyntaxError('Unexpected token', 'x', 0, 1, 1, 4);
+const error3 = new csstree.parse.SyntaxError('Unexpected token', 'x', 0, 1, 1, 4, 5);
+
 // Walking the AST
 csstree.walk(ast, {
     visit: 'Declaration',


### PR DESCRIPTION
The `parse` function actually has [two additional properties](https://github.com/eslint/csstree/blob/b403ffb6085d5e8c481f62026d88eebd632a3cb5/lib/parser/create.js#L384-L387):

1. `SyntaxError` - the error used for parsing errors internally
2. `config` - the config used to create the function

This PR adds types for these properties.