### PR TITLE
fix: Remove wrong `container-type` property patch

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -218,10 +218,6 @@
             "comment": "added old IE property https://msdn.microsoft.com/en-us/library/ms530723(v=vs.85).aspx",
             "syntax": "<url>+"
         },
-        "container-type": {
-            "comment": "https://www.w3.org/TR/css-contain-3/#propdef-container-type",
-            "syntax": "normal || [ size | inline-size ]"
-        },
         "cue": {
             "comment": "https://www.w3.org/TR/css3-speech/#property-index",
             "syntax": "<'cue-before'> <'cue-after'>?"


### PR DESCRIPTION
depends on https://github.com/mdn/data/pull/955, and as a mirror of https://github.com/csstree/csstree/pull/313