### PR TITLE
fix: Add missing node types and update other types

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -842,6 +842,7 @@ export interface WhiteSpace extends CssNodeCommon {
     value: string;
 }
 
+/* IMPORTANT! If you update this, also update `CssNodePlain` and `CssNodeNames` */
 export type CssNode =
     | AnPlusB
     | Atrule
@@ -885,6 +886,7 @@ export type CssNode =
     | Value
     | WhiteSpace;
 
+/* IMPORTANT! If you update this, also update `CssNode` and `CssNodeNames` */
 export type CssNodePlain =
     | AnPlusB
     | AtrulePlain
@@ -907,6 +909,7 @@ export type CssNodePlain =
     | MediaFeature
     | MediaQueryPlain
     | MediaQueryListPlain
+    | NestingSelector
     | NthPlain
     | NumberNode
     | Operator
@@ -927,6 +930,7 @@ export type CssNodePlain =
     | ValuePlain
     | WhiteSpace;
 
+/* IMPORTANT! If you update this, also update `CssNodePlain` and `CssNode` */
 type CssNodeNames =
     | "AnPlusB"
     | "Atrule"

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -606,6 +606,18 @@ export interface Comment extends CssNodeCommon {
     value: string;
 }
 
+export interface Condition extends CssNodeCommon {
+    type: "Condition";
+    kind: string;
+    children: List<CssNode>;
+}
+
+export interface ConditionPlain extends CssNodeCommon {
+    type: "Condition";
+    kind: string;
+    children: CssNodePlain[];
+}
+
 export interface Declaration extends CssNodeCommon {
     type: "Declaration";
     important: boolean | string;
@@ -855,6 +867,7 @@ export type CssNode =
     | ClassSelector
     | Combinator
     | Comment
+    | Condition
     | Declaration
     | DeclarationList
     | Dimension
@@ -899,6 +912,7 @@ export type CssNodePlain =
     | ClassSelector
     | Combinator
     | Comment
+    | ConditionPlain
     | DeclarationPlain
     | DeclarationListPlain
     | Dimension
@@ -943,6 +957,7 @@ type CssNodeNames =
     | "ClassSelector"
     | "Combinator"
     | "Comment"
+    | "Condition"
     | "Declaration"
     | "DeclarationList"
     | "Dimension"

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -675,6 +675,21 @@ export interface Identifier extends CssNodeCommon {
     name: string;
 }
 
+export interface Layer extends CssNodeCommon {
+    type: "Layer";
+    name: string;
+}
+
+export interface LayerList extends CssNodeCommon {
+    type: "LayerList";
+    children: List<Layer>;
+}
+
+export interface LayerListPlain extends CssNodeCommon {
+    type: "LayerList";
+    children: Layer[];
+}
+
 export interface MediaFeature extends CssNodeCommon {
     type: "MediaFeature";
     name: string;
@@ -819,6 +834,11 @@ export interface StyleSheet extends CssNodeCommon {
     children: List<CssNode>;
 }
 
+export interface SupportsDeclaration extends CssNodeCommon {
+    type: "SupportsDeclaration";
+    declaration: Declaration | Raw;
+}
+
 export interface StyleSheetPlain extends CssNodeCommon {
     type: "StyleSheet";
     children: CssNodePlain[];
@@ -875,6 +895,8 @@ export type CssNode =
     | Hash
     | IdSelector
     | Identifier
+    | Layer
+    | LayerList
     | MediaFeature
     | MediaQuery
     | MediaQueryList
@@ -893,6 +915,7 @@ export type CssNode =
     | SelectorList
     | StringNode
     | StyleSheet
+    | SupportsDeclaration
     | TypeSelector
     | UnicodeRange
     | Url
@@ -920,6 +943,8 @@ export type CssNodePlain =
     | Hash
     | IdSelector
     | Identifier
+    | Layer
+    | LayerListPlain
     | MediaFeature
     | MediaQueryPlain
     | MediaQueryListPlain
@@ -938,6 +963,7 @@ export type CssNodePlain =
     | SelectorListPlain
     | StringNode
     | StyleSheetPlain
+    | SupportsDeclaration
     | TypeSelector
     | UnicodeRange
     | Url
@@ -983,6 +1009,7 @@ type CssNodeNames =
     | "SelectorList"
     | "String"
     | "StyleSheet"
+    | "SupportsDeclaration"
     | "TypeSelector"
     | "UnicodeRange"
     | "Url"

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -905,7 +905,7 @@ export interface WhiteSpace extends CssNodeCommon {
     value: string;
 }
 
-/* IMPORTANT! If you update this, also update `CssNodePlain` and `CssNodeNames` */
+/* IMPORTANT! If you update this, also update `CssNodePlain` */
 export type CssNode =
     | AnPlusB
     | Atrule
@@ -956,7 +956,7 @@ export type CssNode =
     | Value
     | WhiteSpace;
 
-/* IMPORTANT! If you update this, also update `CssNode` and `CssNodeNames` */
+/* IMPORTANT! If you update this, also update `CssNode` */
 export type CssNodePlain =
     | AnPlusB
     | AtrulePlain
@@ -1007,56 +1007,9 @@ export type CssNodePlain =
     | ValuePlain
     | WhiteSpace;
 
-/* IMPORTANT! If you update this, also update `CssNodePlain` and `CssNode` */
-type CssNodeNames =
-    | "AnPlusB"
-    | "Atrule"
-    | "AtrulePrelude"
-    | "AttributeSelector"
-    | "Block"
-    | "Brackets"
-    | "CDC"
-    | "CDO"
-    | "ClassSelector"
-    | "Combinator"
-    | "Comment"
-    | "Condition"
-    | "Declaration"
-    | "DeclarationList"
-    | "Dimension"
-    | "Feature"
-    | "FeatureFunction"
-    | "FeatureRange"
-    | "Function"
-    | "Hash"
-    | "IdSelector"
-    | "Identifier"
-    | "Layer"
-    | "LayerList"
-    | "MediaFeature"
-    | "MediaQuery"
-    | "MediaQueryList"
-    | "NestingSelector"
-    | "Nth"
-    | "Number"
-    | "Operator"
-    | "Parentheses"
-    | "Percentage"
-    | "PseudoClassSelector"
-    | "PseudoElementSelector"
-    | "Ratio"
-    | "Raw"
-    | "Rule"
-    | "Selector"
-    | "SelectorList"
-    | "String"
-    | "StyleSheet"
-    | "SupportsDeclaration"
-    | "TypeSelector"
-    | "UnicodeRange"
-    | "Url"
-    | "Value"
-    | "WhiteSpace";
+type CssNodeNames = CssNode["type"];
+
+type AnyCssNode = CssNode | CssNodePlain;
 
 // ----------------------------------------------------------
 // Tokenizer
@@ -1732,7 +1685,7 @@ export interface GenerateOptions {
  * @param options - Optional configuration for the generator.
  * @returns The generated CSS string.
  */
-export type GenerateFunction = (ast: CssNode, options?: GenerateOptions) => string;
+export type GenerateFunction = (ast: AnyCssNode, options?: GenerateOptions) => string;
 
 /**
  * Generates a CSS string from an abstract syntax tree (AST).
@@ -1764,7 +1717,7 @@ export interface WalkContext {
     /**
      * The root node of the tree being traversed.
      */
-    root: CssNode;
+    root: AnyCssNode;
 
     /**
      * The current stylesheet node being visited, or `null` if not applicable.
@@ -1872,48 +1825,7 @@ export interface WalkOptionsVisit<NodeType extends CssNode = CssNode> {
 /**
  * Combined options for tree-walking, supporting specific node types or general traversal options.
  */
-export type WalkOptions =
-    | WalkOptionsVisit<AnPlusB>
-    | WalkOptionsVisit<Atrule>
-    | WalkOptionsVisit<AtrulePrelude>
-    | WalkOptionsVisit<AttributeSelector>
-    | WalkOptionsVisit<Block>
-    | WalkOptionsVisit<Brackets>
-    | WalkOptionsVisit<CDC>
-    | WalkOptionsVisit<CDO>
-    | WalkOptionsVisit<ClassSelector>
-    | WalkOptionsVisit<Combinator>
-    | WalkOptionsVisit<Comment>
-    | WalkOptionsVisit<Declaration>
-    | WalkOptionsVisit<DeclarationList>
-    | WalkOptionsVisit<Dimension>
-    | WalkOptionsVisit<FunctionNode>
-    | WalkOptionsVisit<Hash>
-    | WalkOptionsVisit<IdSelector>
-    | WalkOptionsVisit<Identifier>
-    | WalkOptionsVisit<MediaFeature>
-    | WalkOptionsVisit<MediaQuery>
-    | WalkOptionsVisit<MediaQueryList>
-    | WalkOptionsVisit<Nth>
-    | WalkOptionsVisit<NumberNode>
-    | WalkOptionsVisit<Operator>
-    | WalkOptionsVisit<Parentheses>
-    | WalkOptionsVisit<Percentage>
-    | WalkOptionsVisit<PseudoClassSelector>
-    | WalkOptionsVisit<PseudoElementSelector>
-    | WalkOptionsVisit<Ratio>
-    | WalkOptionsVisit<Raw>
-    | WalkOptionsVisit<Rule>
-    | WalkOptionsVisit<Selector>
-    | WalkOptionsVisit<SelectorList>
-    | WalkOptionsVisit<StringNode>
-    | WalkOptionsVisit<StyleSheet>
-    | WalkOptionsVisit<TypeSelector>
-    | WalkOptionsVisit<UnicodeRange>
-    | WalkOptionsVisit<Url>
-    | WalkOptionsVisit<Value>
-    | WalkOptionsVisit<WhiteSpace>
-    | WalkOptionsNoVisit;
+export type WalkOptions = WalkOptionsVisit<CssNode> | WalkOptionsNoVisit;
 
 /**
  * Walks through a CSS abstract syntax tree (AST) and invokes callback functions on nodes.
@@ -1925,7 +1837,7 @@ export const walk: {
      * @param ast - The CSS abstract syntax tree to traverse.
      * @param options - The options controlling the traversal process.
      */
-    (ast: CssNode, options: EnterOrLeaveFn | WalkOptions): void;
+    (ast: AnyCssNode, options: EnterOrLeaveFn | WalkOptions): void;
 
     /**
      * Stops traversal. No visitor function will be invoked once this value is returned by a visitor.
@@ -1947,7 +1859,7 @@ export const walk: {
  * @param list - The list containing the current node.
  * @returns `true` if the node matches the condition; `false` otherwise.
  */
-export type FindFn = (this: WalkContext, node: CssNode, item: ListItem<CssNode>, list: List<CssNode>) => boolean;
+export type FindFn = (this: WalkContext, node: AnyCssNode, item: ListItem<CssNode>, list: List<CssNode>) => boolean;
 
 /**
  * Finds the first node in the tree that matches the specified predicate function.
@@ -1956,7 +1868,7 @@ export type FindFn = (this: WalkContext, node: CssNode, item: ListItem<CssNode>,
  * @param fn - The predicate function to match nodes.
  * @returns The first matching node, or `null` if no match is found.
  */
-export function find(ast: CssNode, fn: FindFn): CssNode | null;
+export function find(ast: AnyCssNode, fn: FindFn): AnyCssNode | null;
 
 /**
  * Finds the last node in the tree that matches the specified predicate function.
@@ -1965,7 +1877,7 @@ export function find(ast: CssNode, fn: FindFn): CssNode | null;
  * @param fn - The predicate function to match nodes.
  * @returns The last matching node, or `null` if no match is found.
  */
-export function findLast(ast: CssNode, fn: FindFn): CssNode | null;
+export function findLast(ast: AnyCssNode, fn: FindFn): AnyCssNode | null;
 
 /**
  * Finds all nodes in the tree that match the specified predicate function.
@@ -1974,7 +1886,7 @@ export function findLast(ast: CssNode, fn: FindFn): CssNode | null;
  * @param fn - The predicate function to match nodes.
  * @returns An array of all matching nodes.
  */
-export function findAll(ast: CssNode, fn: FindFn): CssNode[];
+export function findAll(ast: AnyCssNode, fn: FindFn): AnyCssNode[];
 
 // ----------------------------------------------------------
 // Name utils
@@ -3121,7 +3033,7 @@ export class Lexer {
      * @param prelude - The prelude content.
      * @returns The match result as a `LexerMatchResult`.
      */
-    matchAtrulePrelude(atruleName: string, prelude: CssNode | CssNodePlain | string): LexerMatchResult;
+    matchAtrulePrelude(atruleName: string, prelude: AnyCssNode | string): LexerMatchResult;
 
     /**
      * Matches an at-rule descriptor value against its syntax definition.
@@ -3131,7 +3043,7 @@ export class Lexer {
      * @param value - The value to match.
      * @returns The match result as a `LexerMatchResult`.
      */
-    matchAtruleDescriptor(atruleName: string, descriptorName: string, value: CssNode | CssNodePlain | string): LexerMatchResult;
+    matchAtruleDescriptor(atruleName: string, descriptorName: string, value: AnyCssNode | string): LexerMatchResult;
 
     /**
      * Matches a declaration node against its syntax definition.
@@ -3139,7 +3051,7 @@ export class Lexer {
      * @param node - The declaration node to match.
      * @returns The match result as a `LexerMatchResult`.
      */
-    matchDeclaration(node: CssNode | CssNodePlain): LexerMatchResult;
+    matchDeclaration(node: AnyCssNode): LexerMatchResult;
 
     /**
      * Matches a property value against its syntax definition.
@@ -3148,7 +3060,7 @@ export class Lexer {
      * @param value - The value to match.
      * @returns The match result as a `LexerMatchResult`.
      */
-    matchProperty(propertyName: string, value: CssNode | CssNodePlain | string): LexerMatchResult;
+    matchProperty(propertyName: string, value: AnyCssNode | string): LexerMatchResult;
 
     /**
      * Matches a type value against its syntax definition.
@@ -3157,7 +3069,7 @@ export class Lexer {
      * @param value - The value to match.
      * @returns The match result as a `LexerMatchResult`.
      */
-    matchType(typeName: string, value: CssNode | CssNodePlain | string): LexerMatchResult;
+    matchType(typeName: string, value: AnyCssNode | string): LexerMatchResult;
 
     /**
      * Matches a generic syntax descriptor against a value.
@@ -3166,7 +3078,7 @@ export class Lexer {
      * @param value - The value to match.
      * @returns The match result as a `LexerMatchResult`.
      */
-    match(syntax: SyntaxDescriptor | string, value: CssNode | CssNodePlain | string): LexerMatchResult;
+    match(syntax: SyntaxDescriptor | string, value: AnyCssNode | string): LexerMatchResult;
 
     /**
      * Finds fragments of a value that match a specific syntax type and name.
@@ -3177,7 +3089,7 @@ export class Lexer {
      * @param name - The name to match.
      * @returns An array of matching fragments.
      */
-    findValueFragments(propertyName: string, value: CssNode | CssNodePlain, type: string, name: string): FragmentMatch<Value>[];
+    findValueFragments(propertyName: string, value: AnyCssNode, type: string, name: string): FragmentMatch<Value>[];
 
     /**
      * Finds fragments of a declaration value that match a specific syntax type and name.
@@ -3197,7 +3109,7 @@ export class Lexer {
      * @param name - The name to match.
      * @returns An array of matching fragments.
      */
-    findAllFragments(ast: CssNode | CssNodePlain, type: string, name: string): FragmentMatch[];
+    findAllFragments(ast: AnyCssNode, type: string, name: string): FragmentMatch[];
 
     /**
      * Retrieves the syntax descriptor for an at-rule.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -3121,7 +3121,7 @@ export class Lexer {
      * @param prelude - The prelude content.
      * @returns The match result as a `LexerMatchResult`.
      */
-    matchAtrulePrelude(atruleName: string, prelude: CssNode | string): LexerMatchResult;
+    matchAtrulePrelude(atruleName: string, prelude: CssNode | CssNodePlain | string): LexerMatchResult;
 
     /**
      * Matches an at-rule descriptor value against its syntax definition.
@@ -3131,7 +3131,7 @@ export class Lexer {
      * @param value - The value to match.
      * @returns The match result as a `LexerMatchResult`.
      */
-    matchAtruleDescriptor(atruleName: string, descriptorName: string, value: CssNode | string): LexerMatchResult;
+    matchAtruleDescriptor(atruleName: string, descriptorName: string, value: CssNode | CssNodePlain | string): LexerMatchResult;
 
     /**
      * Matches a declaration node against its syntax definition.
@@ -3139,7 +3139,7 @@ export class Lexer {
      * @param node - The declaration node to match.
      * @returns The match result as a `LexerMatchResult`.
      */
-    matchDeclaration(node: CssNode): LexerMatchResult;
+    matchDeclaration(node: CssNode | CssNodePlain): LexerMatchResult;
 
     /**
      * Matches a property value against its syntax definition.
@@ -3148,7 +3148,7 @@ export class Lexer {
      * @param value - The value to match.
      * @returns The match result as a `LexerMatchResult`.
      */
-    matchProperty(propertyName: string, value: CssNode | string): LexerMatchResult;
+    matchProperty(propertyName: string, value: CssNode | CssNodePlain | string): LexerMatchResult;
 
     /**
      * Matches a type value against its syntax definition.
@@ -3157,7 +3157,7 @@ export class Lexer {
      * @param value - The value to match.
      * @returns The match result as a `LexerMatchResult`.
      */
-    matchType(typeName: string, value: CssNode | string): LexerMatchResult;
+    matchType(typeName: string, value: CssNode | CssNodePlain | string): LexerMatchResult;
 
     /**
      * Matches a generic syntax descriptor against a value.
@@ -3166,7 +3166,7 @@ export class Lexer {
      * @param value - The value to match.
      * @returns The match result as a `LexerMatchResult`.
      */
-    match(syntax: SyntaxDescriptor | string, value: CssNode | string): LexerMatchResult;
+    match(syntax: SyntaxDescriptor | string, value: CssNode | CssNodePlain | string): LexerMatchResult;
 
     /**
      * Finds fragments of a value that match a specific syntax type and name.
@@ -3177,7 +3177,7 @@ export class Lexer {
      * @param name - The name to match.
      * @returns An array of matching fragments.
      */
-    findValueFragments(propertyName: string, value: CssNode, type: string, name: string): FragmentMatch<Value>[];
+    findValueFragments(propertyName: string, value: CssNode | CssNodePlain, type: string, name: string): FragmentMatch<Value>[];
 
     /**
      * Finds fragments of a declaration value that match a specific syntax type and name.
@@ -3197,7 +3197,7 @@ export class Lexer {
      * @param name - The name to match.
      * @returns An array of matching fragments.
      */
-    findAllFragments(ast: CssNode, type: string, name: string): FragmentMatch[];
+    findAllFragments(ast: CssNode | CssNodePlain, type: string, name: string): FragmentMatch[];
 
     /**
      * Retrieves the syntax descriptor for an at-rule.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -648,6 +648,37 @@ export interface Dimension extends CssNodeCommon {
     unit: string;
 }
 
+export interface Feature extends CssNodeCommon {
+    type: "Feature";
+    name: string;
+    kind: string;
+    value: Identifier | NumberNode | Dimension | Ratio | FunctionNode | null;
+}
+
+export interface FeatureFunction extends CssNodeCommon {
+    type: "FeatureFunction";
+    feature: string;
+    kind: string;
+    value: Declaration | Selector;
+}
+
+export interface FeatureFunctionPlain extends CssNodeCommon {
+    type: "FeatureFunction";
+    feature: string;
+    kind: string;
+    value: DeclarationPlain | SelectorPlain;
+}
+
+export interface FeatureRange extends CssNodeCommon {
+    type: "FeatureRange";
+    kind: string;
+    left: Identifier | NumberNode | Dimension | Ratio | FunctionNode;
+    leftComparison: string;
+    middle: Identifier | NumberNode | Dimension | Ratio | FunctionNode;
+    rightComparison: string | null;
+    right: Identifier | NumberNode | Dimension | Ratio | FunctionNode | null;
+}
+
 export interface FunctionNode extends CssNodeCommon {
     type: "Function";
     name: string;
@@ -891,6 +922,9 @@ export type CssNode =
     | Declaration
     | DeclarationList
     | Dimension
+    | Feature
+    | FeatureFunction
+    | FeatureRange
     | FunctionNode
     | Hash
     | IdSelector
@@ -939,6 +973,9 @@ export type CssNodePlain =
     | DeclarationPlain
     | DeclarationListPlain
     | Dimension
+    | Feature
+    | FeatureFunctionPlain
+    | FeatureRange
     | FunctionNodePlain
     | Hash
     | IdSelector
@@ -987,10 +1024,15 @@ type CssNodeNames =
     | "Declaration"
     | "DeclarationList"
     | "Dimension"
+    | "Feature"
+    | "FeatureFunction"
+    | "FeatureRange"
     | "Function"
     | "Hash"
     | "IdSelector"
     | "Identifier"
+    | "Layer"
+    | "LayerList"
     | "MediaFeature"
     | "MediaQuery"
     | "MediaQueryList"

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -57,13 +57,13 @@ const declaration = csstree.find(ast, (node) => {
     return node.type === 'Declaration' && node.property === 'color';
 });
 
-declaration satisfies csstree.CssNode | null;
+declaration satisfies csstree.AnyCssNode | null;
 
 const declarations = csstree.findAll(ast, (node) => {
     return node.type === 'Declaration';
 });
 
-declarations satisfies csstree.CssNode[];
+declarations satisfies csstree.AnyCssNode[];
 
 // List manipulation
 const list = new csstree.List<csstree.CssNode>();
@@ -123,6 +123,25 @@ while (!tokenStream.eof) {
     console.log(tokenStream.tokenType);
 }
 
+// Stricter type completeness checks
+type CheckNodeTypesComplete = Exclude<csstree.CssNodeNames, csstree.CssNode['type']> extends never ? true : false;
+type CheckNodeTypesSound = Exclude<csstree.CssNode['type'], csstree.CssNodeNames> extends never ? true : false;
+type CheckPlainTypesComplete = Exclude<csstree.CssNodeNames, csstree.CssNodePlain['type']> extends never ? true : false;
+type CheckPlainTypesSound = Exclude<csstree.CssNodePlain['type'], csstree.CssNodeNames> extends never ? true : false;
+
+// These will error if types don't match
+const _typeChecks: {
+    nodeComplete: CheckNodeTypesComplete extends true ? true : never;
+    nodeSound: CheckNodeTypesSound extends true ? true : never;
+    plainComplete: CheckPlainTypesComplete extends true ? true : never;
+    plainSound: CheckPlainTypesSound extends true ? true : never;
+} = {
+    nodeComplete: true,
+    nodeSound: true,
+    plainComplete: true,
+    plainSound: true
+};
+
 // Definition syntax
 const syntax = csstree.definitionSyntax.parse('<color> | <length>');
 csstree.definitionSyntax.generate(syntax);
@@ -131,7 +150,6 @@ csstree.definitionSyntax.walk(syntax, {
         console.log(node.type);
     }
 });
-
 
 // String encoding/decoding
 const encodedStr = csstree.string.encode('test"string');
@@ -190,3 +208,8 @@ customSyntax.walk(customAst,
         }
     }
 );
+
+const x = (node: csstree.CssNode, nodePlain: csstree.CssNodePlain) => {
+    node.type = nodePlain.type;
+    nodePlain.type = node.type;
+};


### PR DESCRIPTION
The `CssNodePlain` type was missing the `NestingSelector` entry, making it out of sync with `CssNode`. I added `NestingSelector` and some comments to remind people to always update these types at the same time.

I also added several missing node types:

- `Layer`, `LayerList`, and `LayerListPlain`
- `Condition` and `ConditionPlain`
- `Feature`, `FeatureFunction`, `FeatureFunctionPlain`, and `FeatureRange`

Additionally, I updated several method signatures to accept both `CssNode` and `CssNodePlain`.

**Help wanted:** I couldn't quite figure out how to add a test to ensure that everything in `CssNodeNames` matches `CssNode` and `CssNodePlain`.