### PR TITLE
fix: Remove wrong `scroll-timeline` property patch

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -362,13 +362,6 @@
             "comment": "https://www.w3.org/TR/css3-speech/#property-index",
             "syntax": "<time> | none | x-weak | weak | medium | strong | x-strong"
         },
-        "scroll-timeline": {
-            "comment": "fix according to spec",
-            "references": [
-                "https://www.w3.org/TR/scroll-animations-1/#scroll-timeline-shorthand"
-            ],
-            "syntax": "[ <'scroll-timeline-name'> || <'scroll-timeline-axis'> ]#"
-        },
         "src": {
             "comment": "added @font-face's src property https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src",
             "syntax": "[ <url> [ format( <string># ) ]? | local( <family-name> ) ]#"


### PR DESCRIPTION
this patch is not correct: the spec's version and mdn-data's version is both `[ <'scroll-timeline-name'> <'scroll-timeline-axis'>? ]#`, while the patch's version is `[ <'scroll-timeline-name'> || <'scroll-timeline-axis'> ]#`

browsers implement as the spec defines

see https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-timeline and https://drafts.csswg.org/scroll-animations/#propdef-scroll-timeline

this mirrors https://github.com/csstree/csstree/pull/331