### PR TITLE
fix: Remove `src` descriptor patch

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -369,10 +369,6 @@
             ],
             "syntax": "[ <'scroll-timeline-name'> || <'scroll-timeline-axis'> ]#"
         },
-        "src": {
-            "comment": "added @font-face's src property https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src",
-            "syntax": "[ <url> [ format( <string># ) ]? | local( <family-name> ) ]#"
-        },
         "speak": {
             "comment": "https://www.w3.org/TR/css3-speech/#property-index",
             "syntax": "auto | never | always"

--- a/fixtures/definition-syntax/default-properties.json
+++ b/fixtures/definition-syntax/default-properties.json
@@ -27,12 +27,6 @@
             "-webkit-radial-gradient(ellipse at center, #1e5799 0%,#2989d8 50%,#207cca 51%,#7db9e8 100%)"
         ]
     },
-    "src": {
-        "property": "src",
-        "valid": [
-            "local(Example Font), url('examplefont.woff') format(\"woff\"), url('examplefont.woff') format(\"opentype\")"
-        ]
-    },
     "stroke-dasharray": {
         "property": "stroke-dasharray",
         "valid": [


### PR DESCRIPTION
it is a descriptor of `@font-face` at-rule, not a CSS property; so it should not be patched here

this mirrors https://github.com/csstree/csstree/pull/330