### PR TITLE
fix: Remove `unicode-range` descriptor patch

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -409,10 +409,6 @@
             "comment": "added prefixed keywords https://developer.mozilla.org/en-US/docs/Web/CSS/unicode-bidi",
             "syntax": "| -moz-isolate | -moz-isolate-override | -moz-plaintext | -webkit-isolate | -webkit-isolate-override | -webkit-plaintext"
         },
-        "unicode-range": {
-            "comment": "added missed property https://developer.mozilla.org/en-US/docs/Web/CSS/%40font-face/unicode-range",
-            "syntax": "<urange>#"
-        },
         "voice-balance": {
             "comment": "https://www.w3.org/TR/css3-speech/#property-index",
             "syntax": "<number> | left | center | right | leftwards | rightwards"


### PR DESCRIPTION
similar to `src` descriptor, it is also a descriptor of the `@font-face` at-rule; and the patch's syntax is outdated, too

see https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/unicode-range

this mirrors https://github.com/csstree/csstree/pull/332