### PR TITLE
fix: Remove outdated `anchor()` & `anchor-size()` function patch

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -821,24 +821,6 @@
                 "https://drafts.csswg.org/css-anchor-position-1/#typedef-position-area"
             ]
         },
-        "anchor()": {
-            "syntax": "anchor( <anchor-element>? && <anchor-side>, <length-percentage>? )",
-            "comment": "missed",
-            "references": [
-                "https://drafts.csswg.org/css-anchor-position-1/#anchor-pos"
-            ]
-        },
-        "anchor-size()": {
-            "syntax": "anchor-size( [ <anchor-element> || <anchor-size> ]? , <length-percentage>? )",
-            "comment": "missed",
-            "references": [
-                "https://drafts.csswg.org/css-anchor-position-1/#funcdef-anchor-size"
-            ]
-        },
-        "anchor-element": {
-            "syntax": "<dashed-ident>",
-            "comment": "missed, https://drafts.csswg.org/css-anchor-position-1/#typedef-anchor-element"
-        },
         "font-variant-css2": {
             "syntax": "normal | small-caps",
             "comment": "new definition on font-4, https://drafts.csswg.org/css-fonts-4/#font-variant-css21-values"


### PR DESCRIPTION
the spec has renamed `<anchor-element>` to `<anchor-name>`, and the syntax in csstree is outdated; the syntax in mdn-data is the latest which match the spec

see:

https://developer.mozilla.org/en-US/docs/Web/CSS/anchor
https://developer.mozilla.org/en-US/docs/Web/CSS/anchor-size
https://drafts.csswg.org/css-anchor-position-1/#funcdef-anchor
https://drafts.csswg.org/css-anchor-position-1/#funcdef-anchor-size

this mirrors https://github.com/csstree/csstree/pull/334