### PR TITLE
chore: Remove never used syntaxes

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -542,14 +542,6 @@
             "comment": "https://developer.mozilla.org/en-US/docs/Web/CSS/-ms-filter",
             "syntax": "<ident-token> | <function-token> <any-value>? )"
         },
-        "absolute-color-base": {
-            "comment": "https://www.w3.org/TR/css-color-4/#color-syntax",
-            "syntax": "<hex-color> | <absolute-color-function> | <named-color> | transparent"
-        },
-        "absolute-color-function": {
-            "comment": "https://www.w3.org/TR/css-color-4/#color-syntax",
-            "syntax": "<rgb()> | <rgba()> | <hsl()> | <hsla()> | <hwb()> | <lab()> | <lch()> | <oklab()> | <oklch()> | <color()>"
-        },
         "age": {
             "comment": "https://www.w3.org/TR/css3-speech/#voice-family",
             "syntax": "child | young | old"


### PR DESCRIPTION
the `<absolute-color-base>` and `<absolute-color-function>` syntaxes are never used anywhere, neither in mdn-data nor in csstree

also, these syntaxes are not in the https://www.w3.org/TR/css-color-4/#color-syntax reference, too (maybe they are removed from spec long ago)

this mirrors https://github.com/csstree/csstree/pull/335