### PR TITLE
fix: Types for Node definitions

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2704,7 +2704,7 @@ interface StructureDefinition {
 
 interface NodeSyntaxConfig<T extends CssNodeCommon = CssNodeCommon> {
     name: string;
-    structure: StructureDefinition | [];
+    structure: StructureDefinition;
     parse(this: ParserContext): T;
     generate(this: ParserContext, node: T): void;
     walkContext?: string;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2693,19 +2693,21 @@ type ParserContext = TokenStream
         [key: string]: unknown;
     };
 
-interface StructureDescriptor {
-    type: string;
-    optional?: boolean;
-    parse?: (this: ParserContext) => CssNodeCommon;
-    generate?: (this: ParserContext, node: CssNodeCommon) => void;
+type StructureValue = string | Function | null;
+type StructureDescriptor =  StructureValue | Array<StructureValue> | Array<Array<StructureValue>>;
+
+interface StructureDefinition {
+    children?: Array<string>;
+
+    [key: string]: StructureDescriptor | undefined;
 }
 
 interface NodeSyntaxConfig<T extends CssNodeCommon = CssNodeCommon> {
     name: string;
-    structure: Record<string, StructureDescriptor>;
+    structure: StructureDefinition | [];
     parse(this: ParserContext): T;
     generate(this: ParserContext, node: T): void;
-    walkContext: WalkContext;
+    walkContext?: string;
 }
 
 interface AtruleSyntax {

--- a/lib/syntax/node/CDC.js
+++ b/lib/syntax/node/CDC.js
@@ -1,7 +1,7 @@
 import { CDC } from '../../tokenizer/index.js';
 
 export const name = 'CDC';
-export const structure = [];
+export const structure = {};
 
 export function parse() {
     const start = this.tokenStart;

--- a/lib/syntax/node/CDO.js
+++ b/lib/syntax/node/CDO.js
@@ -1,7 +1,7 @@
 import { CDO } from '../../tokenizer/index.js';
 
 export const name = 'CDO';
-export const structure = [];
+export const structure = {};
 
 export function parse() {
     const start = this.tokenStart;

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -97,9 +97,7 @@ const lexer = new csstree.Lexer({
     units: {},
     scope: {},
     features: {},
-    node: {
-        Identifier
-    },
+    node: {},
     atrule: {},
     pseudo: {},
     parseContext: {
@@ -228,6 +226,7 @@ const customSyntax = csstree.fork({
                 return `custom2: ${node.type}`;
             },
             walkContext: 'stylesheet'
+        }
     }
 });
 

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -97,7 +97,9 @@ const lexer = new csstree.Lexer({
     units: {},
     scope: {},
     features: {},
-    node: {},
+    node: {
+        Identifier
+    },
     atrule: {},
     pseudo: {},
     parseContext: {
@@ -197,6 +199,35 @@ const customSyntax = csstree.fork({
     },
     properties: {
         custom: 'CustomNode'
+    },
+    node: {
+        CustomNode: {
+            name: 'CustomNode',
+            structure: {
+                value: 'String'
+            },
+            parse: () => {
+                return {
+                    type: 'CustomNode',
+                    value: 'hello'
+                };
+            },
+            generate: (node) => {
+                return `custom: ${node.type}`;
+            }
+        },
+        CustomNode2: {
+            name: 'CustomNode2',
+            structure: {},
+            parse: () => {
+                return {
+                    type: 'CustomNode2'
+                };
+            },
+            generate: (node) => {
+                return `custom2: ${node.type}`;
+            },
+            walkContext: 'stylesheet'
     }
 });
 


### PR DESCRIPTION
This fixes the types for node definitions, which were previously incorrect.

I used all of the files in https://github.com/eslint/csstree/tree/main/lib/syntax/node as examples and added type test for the `fork()` function to verify.