### PR TITLE
feat: Add support for most CSS nesting rules

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -368,6 +368,10 @@
             "comment": "https://www.w3.org/TR/css3-speech/#property-index",
             "syntax": "<time> | none | x-weak | weak | medium | strong | x-strong"
         },
+        "position-try-options": {
+            "comment": "https://developer.mozilla.org/en-US/docs/Web/CSS/position-try-fallbacks",
+            "syntax": "<'position-try-fallbacks'>"
+        },
         "rest": {
             "comment": "https://www.w3.org/TR/css3-speech/#property-index",
             "syntax": "<'rest-before'> <'rest-after'>?"

--- a/data/patch.json
+++ b/data/patch.json
@@ -348,6 +348,14 @@
             "comment": "extend by vendor keywords https://developer.mozilla.org/en-US/docs/Web/CSS/overflow",
             "syntax": "| <-non-standard-overflow>"
         },
+        "overflow-x": {
+            "comment": "extend by vendor keywords https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-x",
+            "syntax": "| <-non-standard-overflow>"
+        },
+        "overflow-y": {
+            "comment": "extend by vendor keywords https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-y",
+            "syntax": "| <-non-standard-overflow>"
+        },
         "pause": {
             "comment": "https://www.w3.org/TR/css3-speech/#property-index",
             "syntax": "<'pause-before'> <'pause-after'>?"

--- a/fixtures/ast/rule/nesting.json
+++ b/fixtures/ast/rule/nesting.json
@@ -589,9 +589,9 @@
             }
         }
     },
-    "don't parse nested rule when it not started with &": {
-        "source": ".foo{ .bar & { color: green; }; div:hover { color: red; } }",
-        "generate": ".foo{.bar & { color: green; };div:hover { color: red; }}",
+    "nested class selector": {
+        "source": "s{ p:v;.t { a:b } }",
+        "generate": "s{p:v;.t{a:b}}",
         "ast": {
             "type": "Rule",
             "prelude": {
@@ -601,8 +601,8 @@
                         "type": "Selector",
                         "children": [
                             {
-                                "type": "ClassSelector",
-                                "name": "foo"
+                                "type": "TypeSelector",
+                                "name": "s"
                             }
                         ]
                     }
@@ -612,16 +612,364 @@
                 "type": "Block",
                 "children": [
                     {
-                        "type": "Raw",
-                        "value": ".bar & { color: green; };"
+                        "type": "Declaration",
+                        "important": false,
+                        "property": "p",
+                        "value": {
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "v"
+                                }
+                            ]
+                        }
                     },
+                    {
+                        "type": "Rule",
+                        "prelude": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "ClassSelector",
+                                            "name": "t"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "a",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "b"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "nested ID selector": {
+        "source": "s{ p:v; #t { a:b } }",
+        "generate": "s{p:v;#t{a:b}}",
+        "ast": {
+            "type": "Rule",
+            "prelude": {
+                "type": "SelectorList",
+                "children": [
+                    {
+                        "type": "Selector",
+                        "children": [
+                            {
+                                "type": "TypeSelector",
+                                "name": "s"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "block": {
+                "type": "Block",
+                "children": [
                     {
                         "type": "Declaration",
                         "important": false,
-                        "property": "div",
+                        "property": "p",
                         "value": {
-                            "type": "Raw",
-                            "value": "hover { color: red; }"
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "v"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "Rule",
+                        "prelude": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "IdSelector",
+                                            "name": "t"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "a",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "b"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "nested attribute selector": {
+        "source": "s{ p:v; [data-foo] {  a: b}}",
+        "generate": "s{p:v;[data-foo]{a:b}}",
+        "ast": {
+            "type": "Rule",
+            "prelude": {
+                "type": "SelectorList",
+                "children": [
+                    {
+                        "type": "Selector",
+                        "children": [
+                            {
+                                "type": "TypeSelector",
+                                "name": "s"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "block": {
+                "type": "Block",
+                "children": [
+                    {
+                        "type": "Declaration",
+                        "important": false,
+                        "property": "p",
+                        "value": {
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "v"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "Rule",
+                        "prelude": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "AttributeSelector",
+                                            "name": {
+                                                "type": "Identifier",
+                                                "name": "data-foo"
+                                            },
+                                            "matcher": null,
+                                            "value": null,
+                                            "flags": null
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "a",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "b"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "nested universal selector": {
+        "source": "s{ p: v;*   {a:b }  }",
+        "generate": "s{p:v;*{a:b}}",
+        "ast": {
+            "type": "Rule",
+            "prelude": {
+                "type": "SelectorList",
+                "children": [
+                    {
+                        "type": "Selector",
+                        "children": [
+                            {
+                                "type": "TypeSelector",
+                                "name": "s"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "block": {
+                "type": "Block",
+                "children": [
+                    {
+                        "type": "Declaration",
+                        "important": false,
+                        "property": "p",
+                        "value": {
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "v"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "Rule",
+                        "prelude": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "TypeSelector",
+                                            "name": "*"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "a",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "b"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "nested pseudoclass selector": {
+        "source": "s { p:v; :hover { a: b } }",
+        "generate": "s{p:v;:hover{a:b}}",
+        "ast": {
+            "type": "Rule",
+            "prelude": {
+                "type": "SelectorList",
+                "children": [
+                    {
+                        "type": "Selector",
+                        "children": [
+                            {
+                                "type": "TypeSelector",
+                                "name": "s"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "block": {
+                "type": "Block",
+                "children": [
+                    {
+                        "type": "Declaration",
+                        "important": false,
+                        "property": "p",
+                        "value": {
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "v"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "Rule",
+                        "prelude": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "PseudoClassSelector",
+                                            "name": "hover",
+                                            "children": null
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "a",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "b"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
                         }
                     }
                 ]

--- a/lib/syntax/node/Block.js
+++ b/lib/syntax/node/Block.js
@@ -1,13 +1,25 @@
 import {
     WhiteSpace,
     Comment,
+    Delim,
     Semicolon,
+    Hash,
+    Colon,
     AtKeyword,
+    LeftSquareBracket,
     LeftCurlyBracket,
     RightCurlyBracket
 } from '../../tokenizer/index.js';
 
 const AMPERSAND = 0x0026;       // U+0026 AMPERSAND (&)
+const DOT = 0x002E;             // U+002E FULL STOP (.)
+const STAR = 0x002A;            // U+002A ASTERISK (*);
+
+const selectorStarts = new Set([
+    AMPERSAND,
+    DOT,
+    STAR
+]);
 
 function consumeRaw() {
     return this.Raw(null, true);
@@ -30,6 +42,12 @@ function consumeDeclaration() {
     }
 
     return node;
+}
+
+function isSelectorStart() {
+    return this.tokenType === Delim && selectorStarts.has(this.source.charCodeAt(this.tokenStart)) ||
+        this.tokenType === Hash || this.tokenType === LeftSquareBracket ||
+        this.tokenType === Colon;
 }
 
 export const name = 'Block';
@@ -65,7 +83,7 @@ export function parse(isStyleBlock) {
                 break;
 
             default:
-                if (isStyleBlock && this.isDelim(AMPERSAND))  {
+                if (isStyleBlock && isSelectorStart.call(this)) {
                     children.push(consumeRule.call(this));
                 } else {
                     children.push(consumer.call(this));


### PR DESCRIPTION
This pull request implements parsing for most CSS nesting rules. This works for rules beginning with:

* Universal selector
* Attribute selector
* Class name selector
* ID selector
* Pseudoclass/pseudoelement selector

The only I couldn't figure out is the element selector. I've also pushed these changes to https://github.com/csstree/csstree/pull/337 in the hopes to get some feedback on how to do that.

In the meantime, I don't want to hold up getting these changes merged in.

### Enhancements to CSS property handling:
* Added support for `overflow-x` and `overflow-y` properties with vendor-specific keywords in `data/patch.json`.
* Introduced the `position-try-options` property to support fallback strategies for CSS positioning.

### Expansion of test cases for nested CSS rules:
* Replaced the test case for invalid nested rules with new cases for valid nested selectors, including class, ID, attribute, universal, and pseudoclass selectors in `fixtures/ast/rule/nesting.json`. These updates ensure the parser correctly handles a broader range of nested selectors. [[1]](diffhunk://#diff-763ed205797f986e5e95a5ec912b2c055b67a5d5890e8e9b39bb66c53c86616cL592-R628) [[2]](diffhunk://#diff-763ed205797f986e5e95a5ec912b2c055b67a5d5890e8e9b39bb66c53c86616cL605-R638) [[3]](diffhunk://#diff-763ed205797f986e5e95a5ec912b2c055b67a5d5890e8e9b39bb66c53c86616cL615-R972)

### Parsing logic updates:
* Added new token types (`Delim`, `Hash`, `Colon`, `LeftSquareBracket`) and a `selectorStarts` set to identify valid selector starting characters in `lib/syntax/node/Block.js`.
* Updated the `consumeDeclaration` function to include a helper method `isSelectorStart`, which checks for valid selector starting tokens.
* Modified the `parse` function to use `isSelectorStart` for determining whether to consume a rule, enabling support for more selector types.