### PR TITLE
fix: Types for NodeSyntaxConfig

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2697,7 +2697,7 @@ type StructureValue = string | Function | null;
 type StructureDescriptor =  StructureValue | Array<StructureValue> | Array<Array<StructureValue>>;
 
 interface StructureDefinition {
-    children?: Array<string>;
+    children?: Array<Array<string>>;
 
     [key: string]: StructureDescriptor | undefined;
 }
@@ -2712,7 +2712,7 @@ interface NodeSyntaxConfig<T extends CssNodeCommon = CssNodeCommon> {
 
 interface AtruleSyntax {
     prelude: string | null;
-    descriptors: Record<string, string> | null;
+    descriptors?: Record<string, string> | null;
 }
 
 // https://github.com/csstree/csstree/blob/9de5189fadd6fb4e3a149eec0e80d6ed0d0541e5/lib/syntax/config/parser.js#L7-L28

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -194,6 +194,9 @@ const customSyntax = csstree.fork({
                 custom: 'CustomNode'
             }
 
+        },
+        CustomAtRule2: {
+            prelude: 'CustomAtRule2'
         }
     },
     properties: {
@@ -227,6 +230,21 @@ const customSyntax = csstree.fork({
                 return `custom2: ${node.type}`;
             },
             walkContext: 'stylesheet'
+        },
+        CustomNode3: {
+            name: 'CustomNode3',
+            structure: {
+                children: [[]]
+            },
+            parse: () => {
+                return {
+                    type: 'CustomNode3',
+                    value: 'hello'
+                };
+            },
+            generate: (node) => {
+                return `custom3: ${node.type}`;
+            }
         }
     }
 });


### PR DESCRIPTION
I ran into some more incorrect types as I've been working on the CSS plugin. Specifically, the definition for `NodeSyntaxConfig` contained a couple of errors:

- `structure.children` - this needs to be a two-dimensional array of strings
- the `descriptors` property of at-rules is optional