### PR TITLE
fix: Add missing <parenthesis-block> type

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -817,7 +817,7 @@
             "comment": "new definition on font-4, https://drafts.csswg.org/css-fonts-4/#system-family-name-value"
         },
         "parentheses-block": {
-            "comment": "missed, https://drafts.csswg.org/css-syntax/#typedef-parentheses-block",
+            "comment": "missed in mdn-data",
             "syntax": "( <any-value>* )"
         }
     }

--- a/data/patch.json
+++ b/data/patch.json
@@ -815,6 +815,10 @@
         "system-family-name": {
             "syntax": "caption | icon | menu | message-box | small-caption | status-bar",
             "comment": "new definition on font-4, https://drafts.csswg.org/css-fonts-4/#system-family-name-value"
+        },
+        "parentheses-block": {
+            "comment": "missed, https://drafts.csswg.org/css-syntax/#typedef-parentheses-block",
+            "syntax": "( <any-value>* )"
         }
     }
 }


### PR DESCRIPTION
This was causing an error when I tried linting a personal project.