### PR TITLE
fix: Types for default-syntax-data and nodes

### DIFF
--- a/lib/data.d.ts
+++ b/lib/data.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @fileoverview Type definitions for @eslint/css-tree/definition-syntax-data
+ * @author Nicholas C. Zakas
+ */
+
+import type { SyntaxConfig } from "./index.js";
+
+export type DefaultSyntaxConfig = Pick<SyntaxConfig, "atrules" | "types" | "properties">;
+
+declare const defaultConfig: DefaultSyntaxConfig;
+export default defaultConfig;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -522,7 +522,7 @@ export class List<TData> {
 
 export interface CssNodeCommon {
     type: string;
-    loc?: CssLocationRange | undefined;
+    loc?: CssLocationRange | null;
 }
 
 export interface AnPlusB extends CssNodeCommon {
@@ -2705,7 +2705,7 @@ interface StructureDefinition {
 interface NodeSyntaxConfig<T extends CssNodeCommon = CssNodeCommon> {
     name: string;
     structure: StructureDefinition;
-    parse(this: ParserContext): T;
+    parse(this: ParserContext, ...args:Array<unknown>): T;
     generate(this: ParserContext, node: T): void;
     walkContext?: string;
 }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     },
     "./definition-syntax-data": {
       "import": "./lib/data.js",
-      "require": "./cjs/data.cjs"
+      "require": "./cjs/data.cjs",
+      "types": "./lib/data.d.ts"
     },
     "./definition-syntax-data-patch": {
       "import": "./lib/data-patch.js",

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -1,4 +1,5 @@
 import * as csstree from '@eslint/css-tree';
+import defaultSyntax from '@eslint/css-tree/definition-syntax-data';
 
 // Basic parsing and generating
 const ast = csstree.parse('.example { color: red }');
@@ -197,11 +198,14 @@ const customSyntax = csstree.fork({
         },
         CustomAtRule2: {
             prelude: 'CustomAtRule2'
-        }
+        },
+        ...defaultSyntax.atrules
     },
     properties: {
-        custom: 'CustomNode'
+        custom: 'CustomNode',
+        ...defaultSyntax.properties
     },
+    types: defaultSyntax.types,
     node: {
         CustomNode: {
             name: 'CustomNode',
@@ -245,7 +249,7 @@ const customSyntax = csstree.fork({
             generate: (node) => {
                 return `custom3: ${node.type}`;
             }
-        }
+        },
     }
 });
 
@@ -261,4 +265,24 @@ customSyntax.walk(customAst,
 const x = (node: csstree.CssNode, nodePlain: csstree.CssNodePlain) => {
     node.type = nodePlain.type;
     nodePlain.type = node.type;
+};
+
+// parse with custom arguments
+const parse1: csstree.NodeSyntaxConfig["parse"] = function(a, b) {
+
+    return {
+        type: 'Function',
+        loc: this.getLocation(0, this.tokenStart),
+        name: 'Function',
+    };
+};
+
+// parse with no arguments
+const parse2: csstree.NodeSyntaxConfig["parse"] = function() {
+
+    return {
+        type: 'Function',
+        loc: this.getLocation(0, this.tokenStart),
+        name: 'Function',
+    };
 };


### PR DESCRIPTION
Continuing my mission to fix the CSSTree types:

1. Provide definitions for the `/definition-syntax-data` entrypoint
2. Fix the type for `loc` on nodes
3. Allow optional arguments in `NodeSyntaxConfig["parse"]` to align with how `parse` is used in the package.