### PR TITLE
fix: Types for custom nodes and scopes

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2430,6 +2430,17 @@ interface Recognizer {
      */
     getNode(context: ParserContext): (this: ParserContext) => CssNode;
 
+    /**
+     * Any additional methods that return a node or list when called.
+     *
+     * @param context - The parsing context.
+     * @returns A function that produces either a CssNode or List<CssNode>.
+     */
+    [methodName: string]:
+        ((context: ParserContext) => ((this: ParserContext) => CssNode | List<CssNode>)) |
+        ((this: ParserContext, ...args: unknown[]) => CssNode | List<CssNode>) |
+        undefined;
+
     // /**
     //  * Handles whitespace between CSS selectors during parsing.
     //  * Ensures that whitespace is correctly interpreted as a descendant combinator.
@@ -2732,11 +2743,11 @@ export interface SyntaxConfig<T extends CssNodeCommon = CssNodeCommon> {
     types: Record<string, string>;
     properties: Record<string, string>;
     atrules: Record<string, AtruleSyntax>;
-    node: Record<string, NodeSyntaxConfig<T>>;
+    node: Record<string, Partial<NodeSyntaxConfig<T>>>;
     atrule: Record<string, { parse: ConsumerFunction; }>;
     pseudo: Record<string, { parse: ConsumerFunction; }>;
-    scope: Record<string, Recognizer>;
-    features: Record<string, Recognizer>;
+    scope: Record<string, Partial<Recognizer>>;
+    features: Record<string, Partial<Recognizer>>;
     parseContext: ParseContext;
     tokenize: TokenizeFunction;
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2478,9 +2478,6 @@ interface Parser {
 
     /**
      * Reads a sequence of CSS nodes based on the provided recognizer.
-     *
-     * @param recognizer - A recognizer instance to determine node boundaries.
-     * @returns A list of parsed `CssNode` objects.
      */
     readSequence: ReadSequenceFunction;
 

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -261,7 +261,7 @@ const customSyntax = csstree.fork({
     },
     scope: {
         Value: {
-            custom(readSequence, recognizer) {
+            custom() {
                 return this.createList();
             }
         }

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -250,6 +250,21 @@ const customSyntax = csstree.fork({
                 return `custom3: ${node.type}`;
             }
         },
+        CustomNode4: {
+            parse: () => {
+                return {
+                    type: 'CustomNode3',
+                    value: 'hello'
+                };
+            },
+        },
+    },
+    scope: {
+        Value: {
+            custom(readSequence, recognizer) {
+                return this.createList();
+            }
+        }
     }
 });
 


### PR DESCRIPTION
I'm continuing to find incorrect types. This time, the objects passed into `fork()` can actually be partials, so I've updated the corresponding types and tests.