### PR TITLE
feat: Parse nested element selector

### DIFF
--- a/fixtures/ast/rule/nesting.json
+++ b/fixtures/ast/rule/nesting.json
@@ -1383,6 +1383,173 @@
                 ]
             }
         }
+    },
+    "nested element selector with child combinator": {
+        "source": "s { p: v; div > .foo { a: b } }",
+        "generate": "s{p:v;div>.foo{a:b}}",
+        "ast": {
+            "type": "Rule",
+            "prelude": {
+                "type": "SelectorList",
+                "children": [
+                    {
+                        "type": "Selector",
+                        "children": [
+                            {
+                                "type": "TypeSelector",
+                                "name": "s"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "block": {
+                "type": "Block",
+                "children": [
+                    {
+                        "type": "Declaration",
+                        "important": false,
+                        "property": "p",
+                        "value": {
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "v"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "Rule",
+                        "prelude": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "TypeSelector",
+                                            "name": "div"
+                                        },
+                                        {
+                                            "type": "Combinator",
+                                            "name": ">"
+                                        },
+                                        {
+                                            "type": "ClassSelector",
+                                            "name": "foo"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "a",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "b"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "nested element selector with sibling combinator": {
+        "source": "s { p: v; div + .foo { a: b } }",
+        "generate": "s{p:v;div+.foo{a:b}}",
+        "ast": {
+            "type": "Rule",
+            "prelude": {
+                "type": "SelectorList",
+                "children": [
+                    {
+                        "type": "Selector",
+                        "children": [
+                            {
+                                "type": "TypeSelector",
+                                "name": "s"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "block": {
+                "type": "Block",
+                "children": [
+                    {
+                        "type": "Declaration",
+                        "important": false,
+                        "property": "p",
+                        "value": {
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "v"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "Rule",
+                        "prelude": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "TypeSelector",
+                                            "name": "div"
+                                        },
+                                        {
+                                            "type": "Combinator",
+                                            "name": "+"
+                                        },
+                                        {
+                                            "type": "ClassSelector",
+                                            "name": "foo"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "a",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "b"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
     }
-
 }

--- a/fixtures/ast/rule/nesting.json
+++ b/fixtures/ast/rule/nesting.json
@@ -975,5 +975,414 @@
                 ]
             }
         }
+    },
+    "nested element selector": {
+        "source": "s { p: v; div { a: b } }",
+        "generate": "s{p:v;div{a:b}}",
+        "ast": {
+            "type": "Rule",
+            "prelude": {
+                "type": "SelectorList",
+                "children": [
+                    {
+                        "type": "Selector",
+                        "children": [
+                            {
+                                "type": "TypeSelector",
+                                "name": "s"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "block": {
+                "type": "Block",
+                "children": [
+                    {
+                        "type": "Declaration",
+                        "important": false,
+                        "property": "p",
+                        "value": {
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "v"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "Rule",
+                        "prelude": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "TypeSelector",
+                                            "name": "div"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "a",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "b"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "nested element selector with class": {
+        "source": "s { p: v; div.foo { a: b } }",
+        "generate": "s{p:v;div.foo{a:b}}",
+        "ast": {
+            "type": "Rule",
+            "prelude": {
+                "type": "SelectorList",
+                "children": [
+                    {
+                        "type": "Selector",
+                        "children": [
+                            {
+                                "type": "TypeSelector",
+                                "name": "s"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "block": {
+                "type": "Block",
+                "children": [
+                    {
+                        "type": "Declaration",
+                        "important": false,
+                        "property": "p",
+                        "value": {
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "v"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "Rule",
+                        "prelude": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "TypeSelector",
+                                            "name": "div"
+                                        },
+                                        {
+                                            "type": "ClassSelector",
+                                            "name": "foo"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "a",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "b"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "nested element selector with ID": {
+        "source": "s { p: v; div#foo { a: b } }",
+        "generate": "s{p:v;div#foo{a:b}}",
+        "ast": {
+            "type": "Rule",
+            "prelude": {
+                "type": "SelectorList",
+                "children": [
+                    {
+                        "type": "Selector",
+                        "children": [
+                            {
+                                "type": "TypeSelector",
+                                "name": "s"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "block": {
+                "type": "Block",
+                "children": [
+                    {
+                        "type": "Declaration",
+                        "important": false,
+                        "property": "p",
+                        "value": {
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "v"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "Rule",
+                        "prelude": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "TypeSelector",
+                                            "name": "div"
+                                        },
+                                        {
+                                            "type": "IdSelector",
+                                            "name": "foo"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "a",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "b"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "nested element selector with attribute": {
+        "source": "s { p: v; div[data-foo] { a: b } }",
+        "generate": "s{p:v;div[data-foo]{a:b}}",
+        "ast": {
+            "type": "Rule",
+            "prelude": {
+                "type": "SelectorList",
+                "children": [
+                    {
+                        "type": "Selector",
+                        "children": [
+                            {
+                                "type": "TypeSelector",
+                                "name": "s"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "block": {
+                "type": "Block",
+                "children": [
+                    {
+                        "type": "Declaration",
+                        "important": false,
+                        "property": "p",
+                        "value": {
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "v"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "Rule",
+                        "prelude": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "TypeSelector",
+                                            "name": "div"
+                                        },
+                                        {
+                                            "type": "AttributeSelector",
+                                            "name": {
+                                                "type": "Identifier",
+                                                "name": "data-foo"
+                                            },
+                                            "matcher": null,
+                                            "value": null,
+                                            "flags": null
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "a",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "b"
+                                            }
+                                        ]
+                                    }
+
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "nested multiple selectors with element and class": {
+        "source": "s { p: v; div, .foo { a: b } }",
+        "generate": "s{p:v;div,.foo{a:b}}",
+        "ast": {
+            "type": "Rule",
+            "prelude": {
+                "type": "SelectorList",
+                "children": [
+                    {
+                        "type": "Selector",
+                        "children": [
+                            {
+                                "type": "TypeSelector",
+                                "name": "s"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "block": {
+                "type": "Block",
+                "children": [
+                    {
+                        "type": "Declaration",
+                        "important": false,
+                        "property": "p",
+                        "value": {
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "v"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "Rule",
+                        "prelude": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "TypeSelector",
+                                            "name": "div"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "ClassSelector",
+                                            "name": "foo"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "a",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "b"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
     }
+
 }

--- a/lib/syntax/node/Block.js
+++ b/lib/syntax/node/Block.js
@@ -5,6 +5,7 @@ import {
     Semicolon,
     Hash,
     Colon,
+    Ident,
     AtKeyword,
     LeftSquareBracket,
     LeftCurlyBracket,
@@ -44,10 +45,24 @@ function consumeDeclaration() {
     return node;
 }
 
+function isElementSelectorStart() {
+    if (this.tokenType !== Ident) {
+        return false;
+    }
+
+    const nextTokenType = this.lookupTypeNonSC(1);
+
+    if (nextTokenType !== Colon && nextTokenType !== Semicolon && nextTokenType !== RightCurlyBracket) {
+        return true;
+    }
+
+    return false;
+}
+
 function isSelectorStart() {
     return this.tokenType === Delim && selectorStarts.has(this.source.charCodeAt(this.tokenStart)) ||
         this.tokenType === Hash || this.tokenType === LeftSquareBracket ||
-        this.tokenType === Colon;
+        this.tokenType === Colon || isElementSelectorStart.call(this);
 }
 
 export const name = 'Block';
@@ -60,8 +75,7 @@ export const structure = {
     ]]
 };
 
-export function parse(isStyleBlock) {
-    const consumer = isStyleBlock ? consumeDeclaration : consumeRule;
+export function parse(isStyleBlock, allowNestedRules = false) {
     const start = this.tokenStart;
     let children = this.createList();
 
@@ -83,10 +97,16 @@ export function parse(isStyleBlock) {
                 break;
 
             default:
-                if (isStyleBlock && isSelectorStart.call(this)) {
-                    children.push(consumeRule.call(this));
+                if (isStyleBlock) {
+
+                    if (allowNestedRules && isSelectorStart.call(this)) {
+                        children.push(consumeRule.call(this));
+                    } else {
+                        children.push(consumeDeclaration.call(this));
+                    }
+
                 } else {
-                    children.push(consumer.call(this));
+                    children.push(consumeRule.call(this));
                 }
         }
     }

--- a/lib/syntax/node/Block.js
+++ b/lib/syntax/node/Block.js
@@ -75,7 +75,7 @@ export const structure = {
     ]]
 };
 
-export function parse(isStyleBlock, allowNestedRules = false) {
+export function parse(isStyleBlock, { allowNestedRules = false } = {}) {
     const start = this.tokenStart;
     let children = this.createList();
 

--- a/lib/syntax/node/Rule.js
+++ b/lib/syntax/node/Rule.js
@@ -35,7 +35,7 @@ export function parse() {
         prelude = consumeRaw.call(this, startToken);
     }
 
-    block = this.Block(true);
+    block = this.Block(true, true);
 
     return {
         type: 'Rule',
@@ -48,4 +48,3 @@ export function generate(node) {
     this.node(node.prelude);
     this.node(node.block);
 }
-

--- a/lib/syntax/node/Rule.js
+++ b/lib/syntax/node/Rule.js
@@ -35,7 +35,7 @@ export function parse() {
         prelude = consumeRaw.call(this, startToken);
     }
 
-    block = this.Block(true, true);
+    block = this.Block(true, { allowNestedRules: true });
 
     return {
         type: 'Rule',


### PR DESCRIPTION
This adds support for parsing most nested element selectors:

```css
div {
	a {}
	a.foo {}
	a[href] {}
	a, b {}
	a > b {}
	a + b {}
}
```

The only pattern it doesn't currently cover is when a pseudoclass or pseudoelement is immediately attached to the element, like this:

```css
div {
    a:hover {}
}
```

That's because `a:hover` looks like a property and I haven't yet figured out an efficient way to discover whether it's a property or a selector.

refs #33