### PR TITLE
fix: Update MDN data and patch

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -815,10 +815,6 @@
         "system-family-name": {
             "syntax": "caption | icon | menu | message-box | small-caption | status-bar",
             "comment": "new definition on font-4, https://drafts.csswg.org/css-fonts-4/#system-family-name-value"
-        },
-        "parentheses-block": {
-            "comment": "missed in mdn-data",
-            "syntax": "( <any-value>* )"
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.5.4",
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.20.0",
+        "mdn-data": "2.21.0",
         "source-map-js": "^1.0.1"
       },
       "devDependencies": {
@@ -1661,9 +1661,9 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.20.0.tgz",
-      "integrity": "sha512-/d3otgvmquUkAN2RVxSg6lIbQrYX7isR4aC5Hvw8JuHvzctR3eUG50WmsAZjb9MkbJ5LbijPSy7uIxEtQDGI0w==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.21.0.tgz",
+      "integrity": "sha512-+ZKPQezM5vYJIkCxaC+4DTnRrVZR1CgsKLu5zsQERQx6Tea8Y+wMx5A24rq8A8NepCeatIQufVAekKNgiBMsGQ==",
       "license": "CC0-1.0"
     },
     "node_modules/minimatch": {
@@ -3443,9 +3443,9 @@
       }
     },
     "mdn-data": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.20.0.tgz",
-      "integrity": "sha512-/d3otgvmquUkAN2RVxSg6lIbQrYX7isR4aC5Hvw8JuHvzctR3eUG50WmsAZjb9MkbJ5LbijPSy7uIxEtQDGI0w=="
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.21.0.tgz",
+      "integrity": "sha512-+ZKPQezM5vYJIkCxaC+4DTnRrVZR1CgsKLu5zsQERQx6Tea8Y+wMx5A24rq8A8NepCeatIQufVAekKNgiBMsGQ=="
     },
     "minimatch": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "test:types": "tsc -p tests/types/tsconfig.json"
   },
   "dependencies": {
-    "mdn-data": "2.20.0",
+    "mdn-data": "2.21.0",
     "source-map-js": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates the `mdn-data` package and removes entry from `patch.json` that is no longer necessary.