### PR TITLE
fix: isDelim() type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1331,7 +1331,7 @@ export class TokenStream {
      * @param offset - The offset from the current token's starting index (optional). If provided, the function checks the token at the specified offset instead of the current token.
      * @returns True if the token is a delimiter with the specified character code, false otherwise.
      */
-    isDelim(code: number, offset: number): boolean;
+    isDelim(code: number, offset?: number): boolean;
 
     /**
      * Skips a specified number of tokens forward in the stream.

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -313,6 +313,12 @@ customSyntax.walk(customAst,
     }
 );
 
+const readSequence: csstree.ReadSequenceFunction = function (recognizer) {
+    const sequence = this.createList();
+    this.isDelim(5);
+    return sequence;
+};
+
 const x = (node: csstree.CssNode, nodePlain: csstree.CssNodePlain) => {
     node.type = nodePlain.type;
     nodePlain.type = node.type;


### PR DESCRIPTION
Found another type error. The `isDelim()` method has an optional second argument.