### PR TITLE
fix: ParserContext type to have all methods

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2698,10 +2698,13 @@ type ParseConfig = {
 } & Pick<SyntaxConfig, 'features' | 'scope'>;
 
 // https://github.com/csstree/csstree/blob/9de5189fadd6fb4e3a149eec0e80d6ed0d0541e5/lib/parser/create.js#L90
-type ParserContext = TokenStream
+type ParserContext<AvailableNodes extends CssNodeCommon = CssNode> = TokenStream
     & ParseConfig
     & { config: ParseConfig }
     & Parser
+    & {
+        [K in AvailableNodes["type"]]: (this: ParserContext, ...args: unknown[]) => Extract<AvailableNodes, { type: K }>;
+    }
     & {
         // Anything else
         [key: string]: unknown;

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -276,10 +276,13 @@ const customSyntax = csstree.fork({
             structure: {
                 children: [[]]
             },
-            parse: () => {
+            parse() {
+
+                const dec = this.Declaration();
+
                 return {
                     type: 'CustomNode3',
-                    value: 'hello'
+                    value: dec.property
                 };
             },
             generate: (node) => {
@@ -287,10 +290,13 @@ const customSyntax = csstree.fork({
             }
         },
         CustomNode4: {
-            parse: () => {
+            parse() {
+
+                const id = this.Identifier();
+
                 return {
                     type: 'CustomNode3',
-                    value: 'hello'
+                    value: id.name
                 };
             },
         },
@@ -303,6 +309,36 @@ const customSyntax = csstree.fork({
         }
     }
 });
+
+// Parsing with custom node types
+
+interface CustomNode extends csstree.CssNodeCommon {
+    type: 'CustomNode';
+    value: string;
+}
+
+type CustomNodes = csstree.CssNode | CustomNode;
+
+function customParseFunction(this: csstree.ParserContext<CustomNodes>, value: string) {
+
+    const node = this.CustomNode();
+    const id = this.Identifier();
+
+    return {
+        type: 'CustomNode2',
+        value: node.value
+    };
+}
+
+const partialNodeConfig: Partial<csstree.NodeSyntaxConfig> = {
+    parse(this: csstree.ParserContext<CustomNodes>, value: string) {
+        const node = this.CustomNode();
+        return {
+            type: 'CustomNode3',
+            value: node.value
+        };
+    },
+}
 
 const customAst = customSyntax.parse('.example { custom: value }');
 customSyntax.walk(customAst,


### PR DESCRIPTION
The `this` value inside of a node's `parse()` method actually has methods for every registered node type, such as `this.Identifier()`, `this.Declaration()`, etc. It's common for one node's `parse()` method to call another, so including all of these methods by default improves the developer experience greatly.

I also added the ability to augment `ParserContext` with a custom list of nodes to allow for extensions to easily add new nodes and still have good type checking.