### PR TITLE
refactor: Extract children property into interface

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -525,19 +525,19 @@ export interface CssNodeCommon {
     loc?: CssLocationRange | null;
 }
 
-export interface CssParentNodeCommon<T = CssNode> extends CssNodeCommon {
+export interface CssParentNodeCommon<T extends CssNode = CssNode> extends CssNodeCommon {
     children: List<T>;
 }
 
-export interface CssParentNodeCommonPlain<T = CssNodePlain> extends CssNodeCommon {
+export interface CssParentNodeCommonPlain<T extends CssNodePlain = CssNodePlain> extends CssNodeCommon {
     children: T[];
 }
 
-export interface CssOptionalParentNodeCommon<T = CssNode> extends CssNodeCommon {
+export interface CssOptionalParentNodeCommon<T extends CssNode = CssNode> extends CssNodeCommon {
     children: List<T> | null;
 }
 
-export interface CssOptionalParentNodeCommonPlain<T = CssNodePlain> extends CssNodeCommon {
+export interface CssOptionalParentNodeCommonPlain<T extends CssNodePlain = CssNodePlain> extends CssNodeCommon {
     children: T[] | null;
 }
 


### PR DESCRIPTION
This PR extracts the common `children` property into helper interfaces.

- `CssParentNodeCommon` - for regular nodes that always have children
- `CssParentNodeCommonPlain` - for plain nodes that always have children
- `CssOptionalParentNodeCommon` - for regular nodes that sometimes have children
- `CssOptionalParentNodeCommonPlain` - for plain nodes that always have children

This makes it easier when people are defining custom node types to quickly ensure their nodes are implementing `children` the correct way.

No test updates because this is a structural refactor so it doesn't change how the types work, just how they are organized.