### PR TITLE
fix: Revert "fix: Remove outdated `@font-face/unicode-range` descriptor patch"

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -6,6 +6,14 @@
         "container": {
             "prelude": "[ <container-name> ]? <container-condition>"
         },
+        "font-face": {
+            "descriptors": {
+                "unicode-range": {
+                    "comment": "replaces <unicode-range>, an old production name",
+                    "syntax": "<urange>#"
+                }
+            }
+        },
         "nest": {
             "prelude": "<complex-selector-list>"
         },


### PR DESCRIPTION
Reverts eslint/csstree#26 so we can unblock https://github.com/eslint/csstree/issues/60 pending a more permanent solution.