### PR TITLE
fix: allow relative color syntax for rgb()

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -774,10 +774,10 @@
             "syntax": "color( <colorspace-params> [ / [ <alpha-value> | none ] ]? )"
         },
         "rgb()": {
-           "syntax": "rgb( <number>#{3} , <alpha-value>? ) | rgb( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? ) | rgb( from <color> [ <number> | <percentage> | <component-ident> | <calc()> ]{3} [ / [ <alpha-value> | <component-ident> | <calc()> ] ]? )"
+            "syntax": "rgb( <number>#{3} , <alpha-value>? ) | rgb( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? ) | rgb( from <color> [ <number> | <percentage> | <component-ident> | <calc()> ]{3} [ / [ <alpha-value> | <component-ident> | <calc()> ] ]? )"
         },
         "rgba()": {
-           "syntax": "rgba( <number>#{3} , <alpha-value>? ) | rgba( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? ) | rgba( from <color> [ <number> | <percentage> | <component-ident> | <calc()> ]{3} [ / [ <alpha-value> | <component-ident> | <calc()> ] ]? )"
+            "syntax": "rgba( <number>#{3} , <alpha-value>? ) | rgba( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? ) | rgba( from <color> [ <number> | <percentage> | <component-ident> | <calc()> ]{3} [ / [ <alpha-value> | <component-ident> | <calc()> ] ]? )"
         },
         "colorspace-params": {
             "syntax": "[ <predefined-rgb-params> | <xyz-params>]"

--- a/data/patch.json
+++ b/data/patch.json
@@ -584,6 +584,9 @@
             "comment": "missed, https://drafts.csswg.org/css-contain-3/#container-rule",
             "syntax": "not <query-in-parens> | <query-in-parens> [ [ and <query-in-parens> ]* | [ or <query-in-parens> ]* ]"
         },
+        "component-ident": {
+            "syntax": "r | g | b | alpha"
+        },
         "coord-box": {
             "syntax": "content-box | padding-box | border-box | fill-box | stroke-box | view-box"
         },
@@ -769,6 +772,12 @@
         },
         "color()": {
             "syntax": "color( <colorspace-params> [ / [ <alpha-value> | none ] ]? )"
+        },
+        "rgb()": {
+           "syntax": "rgb( <number>#{3} , <alpha-value>? ) | rgb( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? ) | rgb( from <color> [ <number> | <percentage> | <component-ident> | <calc()> ]{3} [ / [ <alpha-value> | <component-ident> | <calc()> ] ]? )"
+        },
+        "rgba()": {
+           "syntax": "rgba( <number>#{3} , <alpha-value>? ) | rgba( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? ) | rgba( from <color> [ <number> | <percentage> | <component-ident> | <calc()> ]{3} [ / [ <alpha-value> | <component-ident> | <calc()> ] ]? )"
         },
         "colorspace-params": {
             "syntax": "[ <predefined-rgb-params> | <xyz-params>]"

--- a/lib/__tests/lexer-relative-colors.js
+++ b/lib/__tests/lexer-relative-colors.js
@@ -1,0 +1,134 @@
+import assert from 'assert';
+import { lexer } from '../index.js';
+
+describe('lexer relative colors', () => {
+    describe('rgb() with relative colors', () => {
+        it('should match rgb(25 25 25 / 50%)', () => {
+            const result = lexer.matchProperty('color', 'rgb(25 25 25 / 50%)');
+
+            assert(result.matched, 'Should match relative color syntax');
+        });
+
+        it('should match rgb(from hsl(0 100% 50%) r g b)', () => {
+            const result = lexer.matchProperty('color', 'rgb(from hsl(0 100% 50%) r g b)');
+
+            assert(result.matched, 'Should match relative color syntax');
+        });
+
+        it('should match rgb(from hsl(0 100% 50%) 132 132 224)', () => {
+            const result = lexer.matchProperty('color', 'rgb(from hsl(0 100% 50%) 132 132 224)');
+
+            assert(result.matched, 'Should match relative color syntax');
+        });
+
+        it('should match rgb(from #123456 calc(r + 40) calc(g + 40) b)', () => {
+            const result = lexer.matchProperty('color', 'rgb(from #123456 calc(r + 40) calc(g + 40) b)');
+
+            assert(result.matched, 'Should match relative color with calc functions');
+        });
+
+        it('should match rgb(from hwb(120deg 10% 20%) r g calc(b + 200))', () => {
+            const result = lexer.matchProperty('color', 'rgb(from hwb(120deg 10% 20%) r g calc(b + 200))');
+
+            assert(result.matched, 'Should match relative color with hwb and calc');
+        });
+
+        it('should match rgb(25 25 25 / 50%)', () => {
+            const result = lexer.matchProperty('color', 'rgb(25 25 25 / 50%)');
+
+            assert(result.matched, 'Should match relative color syntax');
+        });
+
+        it('should match rgb(from hsl(0 100% 50%) r 80 80)', () => {
+            const result = lexer.matchProperty('color', 'rgb(from hsl(0 100% 50%) r 80 80)');
+
+            assert(result.matched, 'Should match relative color syntax');
+        });
+
+        it('should match rgb(from hsl(0 100% 50% / 0.8) r g b / alpha)', () => {
+            const result = lexer.matchProperty('color', 'rgb(from hsl(0 100% 50% / 0.8) r g b / alpha)');
+
+            assert(result.matched, 'Should match relative color syntax');
+        });
+
+        it('should match rgb(from hsl(0 100% 50% / 0.8) r g b / 0.5)', () => {
+            const result = lexer.matchProperty('color', 'rgb(from hsl(0 100% 50% / 0.8) r g b / 0.5)');
+
+            assert(result.matched, 'Should match relative color syntax');
+        });
+
+        it('should match rgb(from hsl(0 100% 50%) calc(r/2) calc(g + 25) calc(b + 175) / calc(alpha - 0.1))', () => {
+            const result = lexer.matchProperty('color', 'rgb(from hsl(0 100% 50%) calc(r/2) calc(g + 25) calc(b + 175) / calc(alpha - 0.1))');
+
+            assert(result.matched, 'Should match relative color syntax');
+        });
+    });
+
+    describe('rgba() with relative colors', () => {
+        it('should match rgba(25 25 25)', () => {
+            const result = lexer.matchProperty('color', 'rgba(25 25 25)');
+
+            assert(result.matched, 'Should match relative color syntax');
+        });
+
+        it('should match rgba(25 25 25 / 50%)', () => {
+            const result = lexer.matchProperty('color', 'rgba(25 25 25 / 50%)');
+
+            assert(result.matched, 'Should match relative color syntax');
+        });
+
+        it('should match rgba(from hsl(0 100% 50%) r g b)', () => {
+            const result = lexer.matchProperty('color', 'rgba(from hsl(0 100% 50%) r g b)');
+
+            assert(result.matched, 'Should match relative color syntax');
+        });
+
+        it('should match rgba(from hsl(0 100% 50%) 132 132 224)', () => {
+            const result = lexer.matchProperty('color', 'rgba(from hsl(0 100% 50%) 132 132 224)');
+
+            assert(result.matched, 'Should match relative color syntax');
+        });
+
+        it('should match rgba(from #123456 calc(r + 40) calc(g + 40) b)', () => {
+            const result = lexer.matchProperty('color', 'rgba(from #123456 calc(r + 40) calc(g + 40) b)');
+
+            assert(result.matched, 'Should match relative color with calc functions');
+        });
+
+        it('should match rgba(from hwb(120deg 10% 20%) r g calc(b + 200))', () => {
+            const result = lexer.matchProperty('color', 'rgba(from hwb(120deg 10% 20%) r g calc(b + 200))');
+
+            assert(result.matched, 'Should match relative color with hwb and calc');
+        });
+
+        it('should match rgba(25 25 25 / 50%)', () => {
+            const result = lexer.matchProperty('color', 'rgba(25 25 25 / 50%)');
+
+            assert(result.matched, 'Should match relative color syntax');
+        });
+
+        it('should match rgba(from hsl(0 100% 50%) r 80 80)', () => {
+            const result = lexer.matchProperty('color', 'rgba(from hsl(0 100% 50%) r 80 80)');
+
+            assert(result.matched, 'Should match relative color syntax');
+        });
+
+        it('should match rgba(from hsl(0 100% 50% / 0.8) r g b / alpha)', () => {
+            const result = lexer.matchProperty('color', 'rgba(from hsl(0 100% 50% / 0.8) r g b / alpha)');
+
+            assert(result.matched, 'Should match relative color syntax');
+        });
+
+        it('should match rgba(from hsl(0 100% 50% / 0.8) r g b / 0.5)', () => {
+            const result = lexer.matchProperty('color', 'rgba(from hsl(0 100% 50% / 0.8) r g b / 0.5)');
+
+            assert(result.matched, 'Should match relative color syntax');
+        });
+
+        it('should match rgba(from hsl(0 100% 50%) calc(r/2) calc(g + 25) calc(b + 175) / calc(alpha - 0.1))', () => {
+            const result = lexer.matchProperty('color', 'rgba(from hsl(0 100% 50%) calc(r/2) calc(g + 25) calc(b + 175) / calc(alpha - 0.1))');
+
+            assert(result.matched, 'Should match relative color syntax');
+        });
+    });
+});


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Fix https://github.com/eslint/css/issues/235

#### What changes did you make? (Give an overview)

Allow relative color syntax for rgb() and rgba(), following syntaxes are now valid:

```js
/* Relative values */
rgb(from green r g b / 0.5)
rgb(from #123456 calc(r + 40) calc(g + 40) b)
rgb(from hwb(120deg 10% 20%) r g calc(b + 200))
rgb(from hsl(0 100% 50%) r g b)
rgb(from hsl(0 100% 50% / 0.8) r g b / alpha)
rgb(from hsl(0 100% 50% / 0.8) r g b / 0.5)
rgb(from hsl(0 100% 50%) calc(r/2) calc(g + 25) calc(b + 175) / calc(alpha - 0.1))
```

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
