### PR TITLE
ci: add Node.js 24 and 25 to `build.yml`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,8 @@ jobs:
                     - 18
                     - 20
                     - 22
+                    - 24
+                    - 25
                 include:
                     - os: windows-latest
                       node: 10


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

In this PR, I've added Node.js 24 and 25 to `build.yml`. 

Node.js 24 test was missing and Node.js 25 was released two days ago, so I added them.

Ref: https://github.com/nodejs/node/releases/tag/v25.0.0

#### What changes did you make? (Give an overview)

In this PR, I've added Node.js 24 and 25 to `build.yml`. 

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A