### PR TITLE
fix: allow declarations inside nested `@layer` rules

### DIFF
--- a/fixtures/ast/rule/nesting.json
+++ b/fixtures/ast/rule/nesting.json
@@ -589,6 +589,105 @@
             }
         }
     },
+    "nested @layer": {
+        "source": ".test { @layer base { color: red; .nested { color: blue } } }",
+        "generate": ".test{@layer base{color:red;.nested{color:blue}}}",
+        "ast": {
+            "type": "Rule",
+            "prelude": {
+                "type": "SelectorList",
+                "children": [
+                    {
+                        "type": "Selector",
+                        "children": [
+                            {
+                                "type": "ClassSelector",
+                                "name": "test"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "block": {
+                "type": "Block",
+                "children": [
+                    {
+                        "type": "Atrule",
+                        "name": "layer",
+                        "prelude": {
+                            "type": "AtrulePrelude",
+                            "children": [
+                                {
+                                    "type": "LayerList",
+                                    "children": [
+                                        {
+                                            "type": "Layer",
+                                            "name": "base"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "color",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "red"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "Rule",
+                                    "prelude": {
+                                        "type": "SelectorList",
+                                        "children": [
+                                            {
+                                                "type": "Selector",
+                                                "children": [
+                                                    {
+                                                        "type": "ClassSelector",
+                                                        "name": "nested"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "block": {
+                                        "type": "Block",
+                                        "children": [
+                                            {
+                                                "type": "Declaration",
+                                                "important": false,
+                                                "property": "color",
+                                                "value": {
+                                                    "type": "Value",
+                                                    "children": [
+                                                        {
+                                                            "type": "Identifier",
+                                                            "name": "blue"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
     "nested class selector": {
         "source": "s{ p:v;.t { a:b } }",
         "generate": "s{p:v;.t{a:b}}",

--- a/lib/syntax/atrule/layer.js
+++ b/lib/syntax/atrule/layer.js
@@ -5,8 +5,8 @@ export default {
                 this.LayerList()
             );
         },
-        block() {
-            return this.Block(false);
+        block(nested = false, { allowNestedRules = false } = {}) {
+            return this.Block(nested, { allowNestedRules });
         }
     }
 };


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

This PR fixes a parsing issue where nested `@layer` rules would throw an error when containing declarations.

#### What changes did you make? (Give an overview)

- Updated `lib/syntax/atrule/layer.js` to correctly propagate `isStyleBlock` and `options` to `this.Block()`.
- Added a regression test case in `fixtures/ast/rule/nesting.json` covering a nested `@layer` rule containing both properties and nested rules.

#### Related Issues

Fixes #106

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
