### PR TITLE
ci: pin Node.js 25.6.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
                     - 20
                     - 22
                     - 24
-                    - 25
+                    - 25.6.1
                 include:
                     - os: windows-latest
                       node: 10


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Pins Node 25.x to 25.6.1 in CI.

Recently released Node 25.7.0 has a bug that causes our CI to fail: https://github.com/nodejs/node/issues/61971

#### What changes did you make? (Give an overview)

Updated `.github/workflows/build.yml`.

#### Related Issues

#113, https://github.com/eslint/eslint/issues/20567

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
