### PR TITLE
fix: correct Lexer#getAtruleDescriptor lookup

### DIFF
--- a/lib/__tests/lexer-get-atrule-descriptor.js
+++ b/lib/__tests/lexer-get-atrule-descriptor.js
@@ -1,0 +1,47 @@
+import assert from 'assert';
+import { lexer, fork } from '@eslint/css-tree';
+
+describe('Lexer#getAtruleDescriptor()', () => {
+    it('should return a descriptor', () => {
+        const descriptor = lexer.getAtruleDescriptor('font-face', 'font-family');
+
+        assert.deepStrictEqual({
+            type: descriptor.type,
+            name: descriptor.name,
+            parent: descriptor.parent
+        }, {
+            type: 'AtruleDescriptor',
+            name: 'font-family',
+            parent: 'font-face'
+        });
+    });
+
+    it('should resolve vendor-prefixed names with basename fallback and prefer exact matches', () => {
+        const customSyntax = fork(prev => ({
+            ...prev,
+            atrules: {
+                'font-face': {
+                    descriptors: {
+                        'font-display': 'auto | block | swap | fallback | optional',
+                        '-foo-font-display': 'auto | xxx'
+                    }
+                }
+            }
+        }));
+
+        assert.strictEqual(
+            customSyntax.lexer.getAtruleDescriptor('font-face', '-vendor-font-display').name,
+            'font-display'
+        );
+        assert.strictEqual(
+            customSyntax.lexer.getAtruleDescriptor('font-face', '-foo-font-display').name,
+            '-foo-font-display'
+        );
+    });
+
+    it('should return null for unknown descriptors', () => {
+        assert.strictEqual(lexer.getAtruleDescriptor('font-face', 'color'), null);
+        assert.strictEqual(lexer.getAtruleDescriptor('keyframes', 'font-family'), null);
+        assert.strictEqual(lexer.getAtruleDescriptor('foo', 'font-family'), null);
+    });
+});

--- a/lib/lexer/Lexer.js
+++ b/lib/lexer/Lexer.js
@@ -439,9 +439,13 @@ export class Lexer {
         return atrule && atrule.prelude || null;
     }
     getAtruleDescriptor(atruleName, name) {
-        return this.atrules.hasOwnProperty(atruleName) && this.atrules.declarators
-            ? this.atrules[atruleName].declarators[name] || null
+        const atrule = this.getAtrule(atruleName);
+        const descriptor = names.keyword(name);
+        const descriptorEntry = atrule && atrule.descriptors
+            ? atrule.descriptors[descriptor.name] || atrule.descriptors[descriptor.basename]
             : null;
+
+        return descriptorEntry || null;
     }
     getProperty(propertyName, fallbackBasename = true) {
         const property = names.property(propertyName);


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What did you do?

Called `Lexer#getAtruleDescriptor()` with a valid at-rule and descriptor:

```js
import { lexer } from '@eslint/css-tree';

lexer.getAtruleDescriptor('font-face', 'font-family');
```

#### What did you expect to happen?

Expected it to return the matching descriptor object, similar to:

```js
{
  type: 'AtruleDescriptor',
  name: 'font-family',
  parent: 'font-face',
  // ...
}
```

#### What actually happened?

It threw `TypeError: this.atrules.hasOwnProperty is not a function` instead of returning the descriptor.

#### What is the purpose of this pull request?

This PR fixes `Lexer#getAtruleDescriptor()` so valid lookups no longer fail with `TypeError: this.atrules.hasOwnProperty is not a function` and the method returns the expected descriptor or `null`.

#### What changes did you make? (Give an overview)

- Updated `getAtruleDescriptor()` to use the correct at-rule descriptor lookup.
- Added regression tests.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
