### PR TITLE
ci: Add explicit permissions to workflows

### DIFF
--- a/.github/workflows/add-to-triage.yml
+++ b/.github/workflows/add-to-triage.yml
@@ -12,6 +12,9 @@ on:
             - opened
             - reopened
 
+permissions:
+    contents: read
+
 jobs:
     add-to-triage:
         uses: eslint/workflows/.github/workflows/add-to-triage.yml@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
 env:
     PRIMARY_NODEJS_VERSION: 24.x
 
+permissions:
+    contents: read
+
 jobs:
     lint:
         name: Lint

--- a/.github/workflows/ci-package-manager.yml
+++ b/.github/workflows/ci-package-manager.yml
@@ -9,6 +9,9 @@ on:
         branches:
             - main
 
+permissions:
+    contents: read
+
 jobs:
     ci-package-manager:
         uses: eslint/workflows/.github/workflows/ci-package-manager.yml@main

--- a/.github/workflows/update-mdn-data.yml
+++ b/.github/workflows/update-mdn-data.yml
@@ -5,6 +5,9 @@ on:
     schedule:
         - cron: "0 0 * * 0" # Runs every Sunday at midnight UTC
 
+permissions:
+    contents: read
+
 jobs:
     update-mdn-data:
         runs-on: ubuntu-latest

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -6,6 +6,9 @@ on:
 
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
     update-readme:
         uses: eslint/workflows/.github/workflows/update-readme.yml@main


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Hardens CI security by explicitly declaring least-privilege `GITHUB_TOKEN` permissions for workflows that currently inherit the repository’s default permissions.

#### What changes did you make? (Give an overview)

 Added a workflow-level `permissions: contents: read` declaration to five workflows:

  * `add-to-triage.yml`, `update-readme.yml`, and `ci-package-manager.yml` call reusable workflows from `eslint/workflows`. Any write operations are authenticated using dedicated PAT secrets (`PROJECT_BOT_TOKEN` or `WORKFLOW_PUSH_BOT_TOKEN`), rather than `GITHUB_TOKEN`.
  * `build.yml` runs linting and tests. Its `GITHUB_TOKEN` is only passed to the Coveralls action for repository identification and is not used for GitHub API write operations.
  * `update-mdn-data.yml` creates update pull requests using `WORKFLOW_PUSH_BOT_TOKEN`, rather than `GITHUB_TOKEN`.

These changes do not affect the workflows’ behavior. They only reduce the potential impact if a workflow step is compromised. `release-please.yml` was left unchanged because it already declares job-level permissions. 

This follows the approach used in [`eslint/.github#20`](https://github.com/eslint/.github/pull/20).

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
