### PR TITLE
fix: allow page margin properties in `@page` rules

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -21,6 +21,15 @@
                 "font-display": "auto | block | swap | fallback | optional"
             }
         },
+        "page": {
+            "descriptors": {
+                "margin-top": "<'margin-top'>",
+                "margin-right": "<'margin-right'>",
+                "margin-bottom": "<'margin-bottom'>",
+                "margin-left": "<'margin-left'>",
+                "margin": "<'margin'>"
+            }
+        },
         "scope": {
             "prelude": "[ ( <scope-start> ) ]? [ to ( <scope-end> ) ]?"
         },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Allow valid page-margin declarations in `@page` rules.

#### What changes did you make? (Give an overview)

Added `margin` and the four physical margin longhands to the `@page` syntax-data patch.

#### Related Issues

Refs https://github.com/eslint/css/issues/519

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
