### PR TITLE
feat: add UnsupportedMatchingTree error for var()/env() matching

### DIFF
--- a/lib/__tests/lexer-match-property.js
+++ b/lib/__tests/lexer-match-property.js
@@ -126,6 +126,26 @@ describe('Lexer#matchProperty()', () => {
         }
     });
 
+    describe('should not be matched to a value with var() or env()', () => {
+        it('var()', () => {
+            const match = lexer.matchProperty('color', 'var(--foo)');
+
+            assert.strictEqual(match.matched, null);
+            assert.strictEqual(match.error.name, 'UnsupportedMatchingTree');
+            assert.strictEqual(match.error.message, 'Matching for a tree with var() is not supported');
+            assert.strictEqual(match.error.code, 'ERR_LEXER_VAR_MATCH_UNSUPPORTED');
+        });
+
+        it('env()', () => {
+            const match = lexer.matchProperty('color', 'env(safe-area-inset-top)');
+
+            assert.strictEqual(match.matched, null);
+            assert.strictEqual(match.error.name, 'UnsupportedMatchingTree');
+            assert.strictEqual(match.error.message, 'Matching for a tree with env() is not supported');
+            assert.strictEqual(match.error.code, 'ERR_LEXER_ENV_MATCH_UNSUPPORTED');
+        });
+    });
+
     it('should not be matched to empty value', () => {
         const match = lexer.matchProperty('color', parse('', { context: 'value', positions: true }));
 
@@ -146,17 +166,11 @@ describe('Lexer#matchProperty()', () => {
                 (it[testState] || it)(name, () => {
                     const match = getMatch(lexer, property, value, syntax);
 
-                    // temporary solution to avoid var() using errors
+                    // temporary solution to avoid var()/env() using errors
                     if (match.error) {
                         if (
-                            /Matching for a tree with var\(\) is not supported/.test(match.error.message) ||
+                            match.error.name === 'UnsupportedMatchingTree' ||
                             /Lexer matching doesn't applicable for custom properties/.test(match.error.message)) {
-                            assert(true);
-                            return;
-                        }
-
-                        if (
-                            /Matching for a tree with env\(\) is not supported/.test(match.error.message)) {
                             assert(true);
                             return;
                         }

--- a/lib/__tests/lexer-match.js
+++ b/lib/__tests/lexer-match.js
@@ -36,6 +36,24 @@ describe('Lexer#match()', () => {
         assert.strictEqual(match.error, null);
     });
 
+    it('should not match a value with var()', () => {
+        const match = customSyntax.lexer.match('fn( <number># )', 'fn(var(--foo))');
+
+        assert.strictEqual(match.matched, null);
+        assert.strictEqual(match.error.name, 'UnsupportedMatchingTree');
+        assert.strictEqual(match.error.message, 'Matching for a tree with var() is not supported');
+        assert.strictEqual(match.error.code, 'ERR_LEXER_VAR_MATCH_UNSUPPORTED');
+    });
+
+    it('should not match a value with env()', () => {
+        const match = customSyntax.lexer.match('fn( <number># )', 'fn(env(safe-area-inset-top))');
+
+        assert.strictEqual(match.matched, null);
+        assert.strictEqual(match.error.name, 'UnsupportedMatchingTree');
+        assert.strictEqual(match.error.message, 'Matching for a tree with env() is not supported');
+        assert.strictEqual(match.error.code, 'ERR_LEXER_ENV_MATCH_UNSUPPORTED');
+    });
+
     it('should fails on bad syntax', () => {
         const value = parse('fn(1, 2, 3)', { context: 'value' });
         const fn = value.children.first;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2382,6 +2382,20 @@ export class SyntaxReferenceError extends SyntaxError {
 }
 
 /**
+ * Represents an error that occurs when a value cannot be matched because it
+ * contains a function whose result is unknown at match time, such as `var()`
+ * or `env()`. Extends the standard `SyntaxError`.
+ */
+export class UnsupportedMatchingTree extends SyntaxError {
+    name: "UnsupportedMatchingTree";
+
+    /**
+     * A stable code identifying which unsupported function prevented matching.
+     */
+    code: "ERR_LEXER_VAR_MATCH_UNSUPPORTED" | "ERR_LEXER_ENV_MATCH_UNSUPPORTED";
+}
+
+/**
  * Represents the result of a lexer match operation.
  */
 export interface LexerMatchResult {
@@ -2398,7 +2412,7 @@ export interface LexerMatchResult {
     /**
      * An error object if a matching error occurred, or `null` if no error.
      */
-    error: Error | SyntaxMatchError | SyntaxReferenceError | null;
+    error: Error | SyntaxMatchError | SyntaxReferenceError | UnsupportedMatchingTree | null;
 
     /**
      * Retrieves the trace of matching operations for a specific node.

--- a/lib/lexer/Lexer.js
+++ b/lib/lexer/Lexer.js
@@ -1,4 +1,4 @@
-import { SyntaxReferenceError, SyntaxMatchError } from './error.js';
+import { SyntaxReferenceError, SyntaxMatchError, UnsupportedMatchingTree } from './error.js';
 import * as names from '../utils/names.js';
 import { cssWideKeywords } from './generic-const.js';
 import { createGenericTypes } from './generic.js';
@@ -87,11 +87,11 @@ function matchSyntax(lexer, syntax, value, useCssWideKeywords) {
     let result;
 
     if (valueHasVar(tokens)) {
-        return buildMatchResult(null, new Error('Matching for a tree with var() is not supported'));
+        return buildMatchResult(null, new UnsupportedMatchingTree('var'));
     }
 
     if (valueHasEnv(tokens)) {
-        return buildMatchResult(null, new Error('Matching for a tree with env() is not supported'));
+        return buildMatchResult(null, new UnsupportedMatchingTree('env'));
     }
 
     if (useCssWideKeywords) {

--- a/lib/lexer/error.js
+++ b/lib/lexer/error.js
@@ -92,6 +92,17 @@ export const SyntaxReferenceError = function(type, referenceName) {
     return error;
 };
 
+export const UnsupportedMatchingTree = function(fnName) {
+    const error = createCustomError(
+        'UnsupportedMatchingTree',
+        `Matching for a tree with ${fnName}() is not supported`
+    );
+
+    error.code = `ERR_LEXER_${fnName.toUpperCase()}_MATCH_UNSUPPORTED`;
+
+    return error;
+};
+
 export const SyntaxMatchError = function(message, syntax, node, matchResult) {
     const error = createCustomError('SyntaxMatchError', message);
     const {

--- a/tests/types/types.test.ts
+++ b/tests/types/types.test.ts
@@ -112,6 +112,13 @@ const propertyMatch = lexer.matchProperty('color', 'red');
 console.log(propertyMatch.matched?.type);
 console.log(propertyMatch.isType(ast, 'color'));
 
+// Unsupported matching tree errors
+const varMatch = lexer.matchProperty('color', 'var(--foo)');
+if (varMatch.error && 'code' in varMatch.error) {
+    varMatch.error satisfies csstree.UnsupportedMatchingTree;
+    varMatch.error.code satisfies "ERR_LEXER_VAR_MATCH_UNSUPPORTED" | "ERR_LEXER_ENV_MATCH_UNSUPPORTED";
+}
+
 lexer.cssWideKeywords satisfies string[];
 lexer.generic satisfies boolean;
 lexer.units.length satisfies string[];


### PR DESCRIPTION
#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

#### AI acknowledgment

- [ ] I did _not_ use AI to generate this PR.
- [x] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Give the "matching is unsupported for this value" errors returned by `Lexer#matchProperty()` / `matchSyntax()` for values containing `var()` or `env()` a stable, documented identity, so consumers (e.g. `eslint/css`) no longer need to compare internal error message strings. Implements the direction agreed in #141: a custom error class that also carries a stable `code` property.

#### What changes did you make? (Give an overview)

- Added an `UnsupportedMatchingTree` error factory in `lib/lexer/error.js`, built via `createCustomError` following the existing `SyntaxReferenceError`/`SyntaxMatchError` pattern. It sets `name: 'UnsupportedMatchingTree'` and a stable `code` property: `ERR_LEXER_VAR_MATCH_UNSUPPORTED` or `ERR_LEXER_ENV_MATCH_UNSUPPORTED`.
- Replaced the two plain `new Error(...)` objects in `matchSyntax()` (`lib/lexer/Lexer.js`) with the new error. The message wording is unchanged, so existing message-based detection keeps working during migration.
- Declared the class in `lib/index.d.ts` (with a literal `name` type) and added it to the `LexerMatchResult.error` union, so TypeScript consumers can narrow via `'code' in match.error` without a cast. Following the existing `SyntaxMatchError`/`SyntaxReferenceError` precedent, the class is not runtime-exported — detection works through the `name`/`code` properties.
- Tests: replaced the message-regex filter in the fixture-driven tests with an `error.name` check, added explicit cases asserting `name`, `message`, and `code` for both `var()` and `env()` through the `matchProperty()` and `match()` paths, and added a compile-only narrowing check to the type tests.

#### Related Issues

fixes #141

#### Is there anything you'd like reviewers to focus on?

No.


Disclosure: I'm a participant of [open source contribution program OSSCA](https://github.com/eslint-ossca)
