### PR TITLE
feat: add `revert-rule` CSS-wide keyword

### DIFF
--- a/fixtures/definition-syntax-match/generic.json
+++ b/fixtures/definition-syntax-match/generic.json
@@ -499,6 +499,7 @@
             "initial",
             "revert",
             "revert-layer",
+            "revert-rule",
             "unset",
             "default",
             "0"

--- a/lib/__tests/helpers/index.js
+++ b/lib/__tests/helpers/index.js
@@ -3,7 +3,8 @@ export const cssWideKeywords = [
     'initial',
     'inherit',
     'revert',
-    'revert-layer'
+    'revert-layer',
+    'revert-rule'
 ];
 
 export function lazyValues(dict) {

--- a/lib/lexer/generic-const.js
+++ b/lib/lexer/generic-const.js
@@ -4,5 +4,6 @@ export const cssWideKeywords = [
     'inherit',
     'unset',
     'revert',
-    'revert-layer'
+    'revert-layer',
+    'revert-rule'
 ];


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR adds [`revert-rule`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/revert-rule) to the set of CSS-wide keywords recognized by the lexer.

#### What changes did you make? (Give an overview)

Added `revert-rule` to the lexer’s CSS-wide keyword list.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
