### PR TITLE
fix: treat `!important` as case-insensitive

### DIFF
--- a/fixtures/ast/declaration/Important.json
+++ b/fixtures/ast/declaration/Important.json
@@ -14,9 +14,10 @@
         },
         {
             "source": "property:!ImpoRtant",
+            "generate": "property:!important",
             "ast": {
                 "type": "Declaration",
-                "important": "ImpoRtant",
+                "important": true,
                 "property": "property",
                 "value": {
                     "type": "Value",
@@ -26,9 +27,10 @@
         },
         {
             "source": "property:!IMPORTANT",
+            "generate": "property:!important",
             "ast": {
                 "type": "Declaration",
-                "important": "IMPORTANT",
+                "important": true,
                 "property": "property",
                 "value": {
                     "type": "Value",

--- a/lib/syntax/node/Declaration.js
+++ b/lib/syntax/node/Declaration.js
@@ -157,9 +157,10 @@ function getImportant() {
     this.eat(Delim);
     this.skipSC();
 
+    const isImportant = this.cmpStr(this.tokenStart, this.tokenEnd, 'important');
     const important = this.consume(Ident);
 
-    // store original value in case it differ from `important`
-    // for better original source restoring and hacks like `!ie` support
-    return important === 'important' ? true : important;
+    // Store non-standard values for better original source restoring and hacks
+    // like `!ie` support.
+    return isImportant ? true : important;
 }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR fixes `!important` being parsed case-sensitively. Per [CSS Syntax](https://www.w3.org/TR/css-syntax-3/#consume-declaration), the `important` identifier is matched ASCII case-insensitively, but it was compared with a strict `===` against the lowercase literal. As a result `!IMPORTANT` and `!ImpoRtant` fell through to the "non-standard value" branch and were stored as raw strings:

```js
import * as csstree from '@eslint/css-tree';

csstree.parse('color: red !IMPORTANT', { context: 'declaration' }).important;
// before: "IMPORTANT"
// after:  true
```

#### What changes did you make? (Give an overview)

Switched the identifier check to `cmpStr` and updated the affected fixtures.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
