### PR TITLE
fix: correct `@font-feature-values` typo in syntax patch

### DIFF
--- a/data/patch.json
+++ b/data/patch.json
@@ -14,9 +14,8 @@
                 }
             }
         },
-        "font-features-values": {
-            "comment": "The features values syntax is defined in https://www.w3.org/TR/css-fonts-4/#at-ruledef-font-feature-values",
-            "prelude": "[<string> | <custom-ident>]+",
+        "font-feature-values": {
+            "comment": "The font-display descriptor: https://www.w3.org/TR/css-fonts-4/#descdef-font-feature-values-font-display",
             "descriptors": {
                 "font-display": "auto | block | swap | fallback | optional"
             }


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR fixes a typo in the syntax patch that leaves `@font-feature-values` without its `font-display` descriptor.

#### What changes did you make? (Give an overview)

Renamed the key to `font-feature-values`.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
