### PR TITLE
fix: allow declarations directly in `@scope` blocks

### DIFF
--- a/fixtures/ast/atrule/atrule/scope.json
+++ b/fixtures/ast/atrule/atrule/scope.json
@@ -164,5 +164,177 @@
                 "children": []
             }
         }
+    },
+    "declarations in block": {
+        "source": "@scope (.foo) { border: 1px solid black; }",
+        "generate": "@scope (.foo){border:1px solid black}",
+        "ast": {
+            "type": "Atrule",
+            "name": "scope",
+            "prelude": {
+                "type": "AtrulePrelude",
+                "children": [
+                    {
+                        "type": "Scope",
+                        "root": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "ClassSelector",
+                                            "name": "foo"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "limit": null
+                    }
+                ]
+            },
+            "block": {
+                "type": "Block",
+                "children": [
+                    {
+                        "type": "Declaration",
+                        "important": false,
+                        "property": "border",
+                        "value": {
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Dimension",
+                                    "value": "1",
+                                    "unit": "px"
+                                },
+                                {
+                                    "type": "Identifier",
+                                    "name": "solid"
+                                },
+                                {
+                                    "type": "Identifier",
+                                    "name": "black"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+    },
+    "declarations and rules in block": {
+        "source": "@scope (.a) to (.b) { color: red; .c { color: green } color: blue }",
+        "generate": "@scope (.a) to (.b){color:red;.c{color:green}color:blue}",
+        "ast": {
+            "type": "Atrule",
+            "name": "scope",
+            "prelude": {
+                "type": "AtrulePrelude",
+                "children": [
+                    {
+                        "type": "Scope",
+                        "root": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "ClassSelector",
+                                            "name": "a"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "limit": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "ClassSelector",
+                                            "name": "b"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "block": {
+                "type": "Block",
+                "children": [
+                    {
+                        "type": "Declaration",
+                        "important": false,
+                        "property": "color",
+                        "value": {
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "red"
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "Rule",
+                        "prelude": {
+                            "type": "SelectorList",
+                            "children": [
+                                {
+                                    "type": "Selector",
+                                    "children": [
+                                        {
+                                            "type": "ClassSelector",
+                                            "name": "c"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "color",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "green"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "type": "Declaration",
+                        "important": false,
+                        "property": "color",
+                        "value": {
+                            "type": "Value",
+                            "children": [
+                                {
+                                    "type": "Identifier",
+                                    "name": "blue"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
     }
 }

--- a/fixtures/ast/rule/nesting.json
+++ b/fixtures/ast/rule/nesting.json
@@ -2365,5 +2365,113 @@
                 ]
             }
         }
+    },
+    "nested @scope": {
+        "source": ".test { @scope (.foo) { color: red; .nested { color: blue } } }",
+        "generate": ".test{@scope (.foo){color:red;.nested{color:blue}}}",
+        "ast": {
+            "type": "Rule",
+            "prelude": {
+                "type": "SelectorList",
+                "children": [
+                    {
+                        "type": "Selector",
+                        "children": [
+                            {
+                                "type": "ClassSelector",
+                                "name": "test"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "block": {
+                "type": "Block",
+                "children": [
+                    {
+                        "type": "Atrule",
+                        "name": "scope",
+                        "prelude": {
+                            "type": "AtrulePrelude",
+                            "children": [
+                                {
+                                    "type": "Scope",
+                                    "root": {
+                                        "type": "SelectorList",
+                                        "children": [
+                                            {
+                                                "type": "Selector",
+                                                "children": [
+                                                    {
+                                                        "type": "ClassSelector",
+                                                        "name": "foo"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "limit": null
+                                }
+                            ]
+                        },
+                        "block": {
+                            "type": "Block",
+                            "children": [
+                                {
+                                    "type": "Declaration",
+                                    "important": false,
+                                    "property": "color",
+                                    "value": {
+                                        "type": "Value",
+                                        "children": [
+                                            {
+                                                "type": "Identifier",
+                                                "name": "red"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "Rule",
+                                    "prelude": {
+                                        "type": "SelectorList",
+                                        "children": [
+                                            {
+                                                "type": "Selector",
+                                                "children": [
+                                                    {
+                                                        "type": "ClassSelector",
+                                                        "name": "nested"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "block": {
+                                        "type": "Block",
+                                        "children": [
+                                            {
+                                                "type": "Declaration",
+                                                "important": false,
+                                                "property": "color",
+                                                "value": {
+                                                    "type": "Value",
+                                                    "children": [
+                                                        {
+                                                            "type": "Identifier",
+                                                            "name": "blue"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
     }
 }

--- a/lib/syntax/atrule/scope.js
+++ b/lib/syntax/atrule/scope.js
@@ -5,8 +5,8 @@ export default {
                 this.Scope()
             );
         },
-        block(nested = false) {
-            return this.Block(nested);
+        block() {
+            return this.Block(true, { allowNestedRules: true });
         }
     }
 };


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What did you do?

```js
import { parse } from '@eslint/css-tree';

parse('@scope (.foo) { border: 1px solid black; }', {
    onParseError(error) {
        console.log(error.formattedMessage);
    }
});
```

### What did you expect to happen?

No parse error. Per [css-cascade-6](https://drafts.csswg.org/css-cascade-6/#scope-syntax), the body of `@scope` is `<block-contents>`, so it accepts declarations as well as rules.

### What actually happened?

Two parse errors:

```
Parse error: Identifier is expected
    1 |@scope (.foo) { border: 1px solid black; }
------------------------------^
Parse error: "{" is expected
    1 |@scope (.foo) { border: 1px solid black; }
------------------------------------------------^
```

#### What is the purpose of this pull request?

This PR fixes `@scope` block parsing so that declarations are accepted directly in the body, in both the top-level and nested positions.

#### What changes did you make? (Give an overview)

`@scope` at-rule now always parses its body as a style block that permits nested rules.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for parsing `@scope` blocks containing declarations and nested rules.
  - Improved handling of nested scoped rules, including selectors, declarations, and scope boundaries.

- **Bug Fixes**
  - Ensured scoped CSS is consistently processed and formatted when declarations and nested rules are combined.

- **Tests**
  - Added coverage for standalone, mixed, and nested `@scope` scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->